### PR TITLE
chore: redirect dependency updates to develop branch

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,7 +16,9 @@ jobs:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.actor.login == 'renovate[bot]'
+      github.event.workflow_run.head_branch != 'main' &&
+      (github.event.workflow_run.actor.login == 'renovate[bot]' ||
+       github.event.workflow_run.actor.login == 'dependabot[bot]')
     steps:
       - name: Get PR number
         id: pr

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "baseBranches": ["develop"],
+  "labels": ["dependencies"]
+}


### PR DESCRIPTION
## Summary

- Add `renovate.json` with `baseBranches: ["develop"]` so Renovate creates PRs against `develop` instead of `main`
- Update auto-merge workflow to support both `renovate[bot]` and `dependabot[bot]`

Dependency updates now flow: Renovate PR → `develop` → manual PR to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)