### PR TITLE
feat(python): expose all 4 new chunking methods + quality metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "cognigraph-python"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cognigraph-chunker",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "cognigraph-chunker",
  "numpy",
  "pyo3",
+ "serde_json",
  "tokio",
 ]
 

--- a/packages/python/Cargo.toml
+++ b/packages/python/Cargo.toml
@@ -11,5 +11,6 @@ crate-type = ["cdylib"]
 cognigraph-chunker = { path = "../.." }
 pyo3 = { version = "0.28", features = ["extension-module"] }
 numpy = "0.28"
-tokio = { version = "1.49", features = ["rt-multi-thread"] }
+tokio = { version = "1.51", features = ["rt-multi-thread"] }
 anyhow = "1.0"
+serde_json = "1.0"

--- a/packages/python/Cargo.toml
+++ b/packages/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognigraph-python"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [lib]

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cognigraph-chunker"
-version = "0.1.0"
+version = "0.2.0"
 requires-python = ">=3.9"
 
 [tool.maturin]

--- a/packages/python/src/adaptive.rs
+++ b/packages/python/src/adaptive.rs
@@ -1,0 +1,280 @@
+//! Python bindings for adaptive chunking.
+
+use pyo3::prelude::*;
+
+use cognigraph_chunker::embeddings::EmbeddingProvider;
+use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
+use cognigraph_chunker::semantic::adaptive_chunk::{
+    AdaptiveConfig as RustAdaptiveConfig, adaptive_chunk,
+};
+use cognigraph_chunker::semantic::adaptive_types::{
+    AdaptiveReport, AdaptiveResult, CandidateScore, ScreeningDecision,
+};
+use cognigraph_chunker::semantic::quality_metrics::MetricWeights;
+
+use crate::error::to_py_err;
+use crate::quality_metrics::{PyMetricWeights, PyQualityMetrics};
+use crate::semantic::RUNTIME;
+use crate::semantic::providers::{PyOllamaProvider, PyOnnxProvider, PyOpenAiProvider};
+
+// ── AdaptiveConfig ────────────────────────────────────────────────────────────
+
+#[pyclass(name = "AdaptiveConfig", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyAdaptiveConfig {
+    #[pyo3(get, set)]
+    pub candidates: Vec<String>,
+    #[pyo3(get, set)]
+    pub force_candidates: bool,
+    #[pyo3(get, set)]
+    pub soft_budget: usize,
+    #[pyo3(get, set)]
+    pub hard_budget: usize,
+    #[pyo3(get, set)]
+    pub metric_weights: Option<PyMetricWeights>,
+    #[pyo3(get, set)]
+    pub sim_window: usize,
+    #[pyo3(get, set)]
+    pub sg_window: usize,
+    #[pyo3(get, set)]
+    pub poly_order: usize,
+}
+
+#[pymethods]
+impl PyAdaptiveConfig {
+    #[new]
+    #[pyo3(signature = (
+        *,
+        candidates=None,
+        force_candidates=false,
+        soft_budget=512,
+        hard_budget=768,
+        metric_weights=None,
+        sim_window=3,
+        sg_window=11,
+        poly_order=3,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        candidates: Option<Vec<String>>,
+        force_candidates: bool,
+        soft_budget: usize,
+        hard_budget: usize,
+        metric_weights: Option<PyMetricWeights>,
+        sim_window: usize,
+        sg_window: usize,
+        poly_order: usize,
+    ) -> Self {
+        Self {
+            candidates: candidates
+                .unwrap_or_else(|| vec!["semantic".to_string(), "cognitive".to_string()]),
+            force_candidates,
+            soft_budget,
+            hard_budget,
+            metric_weights,
+            sim_window,
+            sg_window,
+            poly_order,
+        }
+    }
+}
+
+impl From<&PyAdaptiveConfig> for RustAdaptiveConfig {
+    fn from(py: &PyAdaptiveConfig) -> Self {
+        let metric_weights = py
+            .metric_weights
+            .as_ref()
+            .map(MetricWeights::from)
+            .unwrap_or_default();
+        Self {
+            candidates: py.candidates.clone(),
+            force_candidates: py.force_candidates,
+            soft_budget: py.soft_budget,
+            hard_budget: py.hard_budget,
+            metric_weights,
+            sim_window: py.sim_window,
+            sg_window: py.sg_window,
+            poly_order: py.poly_order,
+        }
+    }
+}
+
+// ── CandidateScore ────────────────────────────────────────────────────────────
+
+#[pyclass(name = "CandidateScore", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyCandidateScore {
+    #[pyo3(get)]
+    pub method: String,
+    #[pyo3(get)]
+    pub metrics: PyQualityMetrics,
+    #[pyo3(get)]
+    pub chunk_count: usize,
+    #[pyo3(get)]
+    pub total_tokens: usize,
+}
+
+impl From<CandidateScore> for PyCandidateScore {
+    fn from(r: CandidateScore) -> Self {
+        Self {
+            method: r.method,
+            metrics: PyQualityMetrics::from(r.metrics),
+            chunk_count: r.chunk_count,
+            total_tokens: r.total_tokens,
+        }
+    }
+}
+
+// ── ScreeningDecision ─────────────────────────────────────────────────────────
+
+#[pyclass(name = "ScreeningDecision", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyScreeningDecision {
+    #[pyo3(get)]
+    pub method: String,
+    #[pyo3(get)]
+    pub included: bool,
+    #[pyo3(get)]
+    pub reason: String,
+}
+
+impl From<ScreeningDecision> for PyScreeningDecision {
+    fn from(r: ScreeningDecision) -> Self {
+        Self {
+            method: r.method,
+            included: r.included,
+            reason: r.reason,
+        }
+    }
+}
+
+// ── AdaptiveReport ────────────────────────────────────────────────────────────
+
+#[pyclass(name = "AdaptiveReport", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyAdaptiveReport {
+    #[pyo3(get)]
+    pub candidates: Vec<PyCandidateScore>,
+    #[pyo3(get)]
+    pub pre_screening: Vec<PyScreeningDecision>,
+    #[pyo3(get)]
+    pub metric_weights: PyMetricWeights,
+}
+
+impl From<AdaptiveReport> for PyAdaptiveReport {
+    fn from(r: AdaptiveReport) -> Self {
+        Self {
+            candidates: r
+                .candidates
+                .into_iter()
+                .map(PyCandidateScore::from)
+                .collect(),
+            pre_screening: r
+                .pre_screening
+                .into_iter()
+                .map(PyScreeningDecision::from)
+                .collect(),
+            metric_weights: PyMetricWeights::from(r.metric_weights),
+        }
+    }
+}
+
+// ── AdaptiveResult ────────────────────────────────────────────────────────────
+
+#[pyclass(name = "AdaptiveResult")]
+pub struct PyAdaptiveResult {
+    #[pyo3(get)]
+    pub winner: String,
+    /// The winner's chunks serialized as a JSON string.
+    #[pyo3(get)]
+    pub chunks_json: String,
+    #[pyo3(get)]
+    pub report: PyAdaptiveReport,
+    #[pyo3(get)]
+    pub count: usize,
+}
+
+impl From<AdaptiveResult> for PyAdaptiveResult {
+    fn from(r: AdaptiveResult) -> Self {
+        let chunks_json = serde_json::to_string(&r.chunks).unwrap_or_else(|_| "[]".to_string());
+        Self {
+            winner: r.winner,
+            chunks_json,
+            report: PyAdaptiveReport::from(r.report),
+            count: r.count,
+        }
+    }
+}
+
+// ── py_adaptive_chunk ─────────────────────────────────────────────────────────
+
+/// Run adaptive chunking, selecting the best method from the configured candidates.
+#[pyfunction]
+#[pyo3(signature = (text, provider, api_key=None, base_url=None, model=None, config=None))]
+pub fn py_adaptive_chunk(
+    py: Python<'_>,
+    text: &str,
+    provider: &Bound<'_, PyAny>,
+    api_key: Option<String>,
+    base_url: Option<String>,
+    model: Option<String>,
+    config: Option<&PyAdaptiveConfig>,
+) -> PyResult<PyAdaptiveResult> {
+    let rust_config = config.map(RustAdaptiveConfig::from).unwrap_or_default();
+    let text_owned = text.to_string();
+
+    // Build optional LLM client
+    let llm_client: Option<CompletionClient> = if api_key.is_some() {
+        let llm_config = LlmConfig::resolve(&api_key, &base_url, &model).map_err(to_py_err)?;
+        Some(CompletionClient::new(llm_config).map_err(to_py_err)?)
+    } else {
+        None
+    };
+
+    let _ = py;
+
+    if let Ok(p) = provider.cast::<PyOllamaProvider>() {
+        let provider_ref = p.borrow();
+        return run_adaptive(
+            &text_owned,
+            &provider_ref.inner,
+            llm_client.as_ref(),
+            &rust_config,
+        );
+    }
+    if let Ok(p) = provider.cast::<PyOpenAiProvider>() {
+        let provider_ref = p.borrow();
+        return run_adaptive(
+            &text_owned,
+            &provider_ref.inner,
+            llm_client.as_ref(),
+            &rust_config,
+        );
+    }
+    if let Ok(p) = provider.cast::<PyOnnxProvider>() {
+        let provider_ref = p.borrow();
+        return run_adaptive(
+            &text_owned,
+            &provider_ref.inner,
+            llm_client.as_ref(),
+            &rust_config,
+        );
+    }
+
+    Err(pyo3::exceptions::PyTypeError::new_err(
+        "provider must be OllamaProvider, OpenAiProvider, or OnnxProvider",
+    ))
+}
+
+fn run_adaptive<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: Option<&CompletionClient>,
+    config: &RustAdaptiveConfig,
+) -> PyResult<PyAdaptiveResult> {
+    let result = RUNTIME
+        .block_on(async { adaptive_chunk(text, provider, llm_client, config).await })
+        .map_err(to_py_err)?;
+
+    Ok(PyAdaptiveResult::from(result))
+}

--- a/packages/python/src/enriched.rs
+++ b/packages/python/src/enriched.rs
@@ -1,0 +1,204 @@
+//! Python bindings for enriched chunking.
+
+use std::collections::HashMap;
+
+use pyo3::prelude::*;
+
+use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
+use cognigraph_chunker::semantic::enriched_chunk::{
+    EnrichedConfig as RustEnrichedConfig, enriched_chunk, enriched_chunk_plain,
+};
+use cognigraph_chunker::semantic::enriched_types::{
+    EnrichedChunk, EnrichedResult, MergeRecord, TypedEntity,
+};
+
+use crate::error::to_py_err;
+use crate::semantic::RUNTIME;
+
+/// Configuration for the enriched chunking pipeline.
+#[pyclass(name = "EnrichedConfig", from_py_object)]
+#[derive(Clone)]
+pub struct PyEnrichedConfig {
+    #[pyo3(get, set)]
+    pub soft_budget: usize,
+    #[pyo3(get, set)]
+    pub hard_budget: usize,
+    #[pyo3(get, set)]
+    pub recombine: bool,
+    #[pyo3(get, set)]
+    pub re_enrich: bool,
+}
+
+#[pymethods]
+impl PyEnrichedConfig {
+    #[new]
+    #[pyo3(signature = (*, soft_budget=512, hard_budget=768, recombine=true, re_enrich=true))]
+    fn new(soft_budget: usize, hard_budget: usize, recombine: bool, re_enrich: bool) -> Self {
+        Self {
+            soft_budget,
+            hard_budget,
+            recombine,
+            re_enrich,
+        }
+    }
+}
+
+impl From<&PyEnrichedConfig> for RustEnrichedConfig {
+    fn from(py: &PyEnrichedConfig) -> Self {
+        Self {
+            soft_budget: py.soft_budget,
+            hard_budget: py.hard_budget,
+            recombine: py.recombine,
+            re_enrich: py.re_enrich,
+        }
+    }
+}
+
+/// A typed entity (name + type label).
+#[pyclass(name = "TypedEntity", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyTypedEntity {
+    #[pyo3(get)]
+    pub name: String,
+    #[pyo3(get)]
+    pub entity_type: String,
+}
+
+/// A record of a merge operation during semantic-key recombination.
+#[pyclass(name = "MergeRecord", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyMergeRecord {
+    #[pyo3(get)]
+    pub result_chunk: usize,
+    #[pyo3(get)]
+    pub source_chunks: Vec<usize>,
+    #[pyo3(get)]
+    pub shared_key: String,
+}
+
+/// A single enriched chunk with full LLM-generated metadata.
+#[pyclass(name = "EnrichedChunk", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyEnrichedChunk {
+    #[pyo3(get)]
+    pub text: String,
+    #[pyo3(get)]
+    pub offset_start: usize,
+    #[pyo3(get)]
+    pub offset_end: usize,
+    #[pyo3(get)]
+    pub token_estimate: usize,
+    #[pyo3(get)]
+    pub title: String,
+    #[pyo3(get)]
+    pub summary: String,
+    #[pyo3(get)]
+    pub keywords: Vec<String>,
+    #[pyo3(get)]
+    pub typed_entities: Vec<PyTypedEntity>,
+    #[pyo3(get)]
+    pub hypothetical_questions: Vec<String>,
+    #[pyo3(get)]
+    pub semantic_keys: Vec<String>,
+    #[pyo3(get)]
+    pub category: String,
+    #[pyo3(get)]
+    pub heading_path: Vec<String>,
+}
+
+/// Result of the enriched chunking pipeline.
+#[pyclass(name = "EnrichedResult")]
+pub struct PyEnrichedResult {
+    #[pyo3(get)]
+    pub chunks: Vec<PyEnrichedChunk>,
+    #[pyo3(get)]
+    pub key_dictionary: HashMap<String, Vec<usize>>,
+    #[pyo3(get)]
+    pub merge_history: Vec<PyMergeRecord>,
+    #[pyo3(get)]
+    pub block_count: usize,
+}
+
+fn convert_result(result: EnrichedResult) -> PyEnrichedResult {
+    let chunks = result
+        .chunks
+        .into_iter()
+        .map(|c: EnrichedChunk| PyEnrichedChunk {
+            text: c.text,
+            offset_start: c.offset_start,
+            offset_end: c.offset_end,
+            token_estimate: c.token_estimate,
+            title: c.title,
+            summary: c.summary,
+            keywords: c.keywords,
+            typed_entities: c
+                .typed_entities
+                .into_iter()
+                .map(|e: TypedEntity| PyTypedEntity {
+                    name: e.name,
+                    entity_type: e.entity_type,
+                })
+                .collect(),
+            hypothetical_questions: c.hypothetical_questions,
+            semantic_keys: c.semantic_keys,
+            category: c.category,
+            heading_path: c.heading_path,
+        })
+        .collect();
+
+    let merge_history = result
+        .merge_history
+        .into_iter()
+        .map(|m: MergeRecord| PyMergeRecord {
+            result_chunk: m.result_chunk,
+            source_chunks: m.source_chunks,
+            shared_key: m.shared_key,
+        })
+        .collect();
+
+    PyEnrichedResult {
+        chunks,
+        key_dictionary: result.key_dictionary,
+        merge_history,
+        block_count: result.block_count,
+    }
+}
+
+/// Run enriched chunking using an LLM (no embedding provider required).
+///
+/// Args:
+///     text: Input text to chunk.
+///     api_key: OpenAI-compatible API key.
+///     base_url: Optional API base URL (defaults to https://api.openai.com/v1).
+///     model: Optional model name (defaults to gpt-4.1-mini).
+///     config: Optional EnrichedConfig instance.
+///     markdown: If True (default), parse input as markdown; otherwise plain text.
+#[pyfunction]
+#[pyo3(signature = (text, api_key, base_url=None, model=None, config=None, *, markdown=true))]
+pub fn py_enriched_chunk(
+    _py: Python<'_>,
+    text: &str,
+    api_key: String,
+    base_url: Option<String>,
+    model: Option<String>,
+    config: Option<&PyEnrichedConfig>,
+    markdown: bool,
+) -> PyResult<PyEnrichedResult> {
+    let rust_config = config.map(RustEnrichedConfig::from).unwrap_or_default();
+    let text_owned = text.to_string();
+
+    let llm_config = LlmConfig::resolve(&Some(api_key), &base_url, &model).map_err(to_py_err)?;
+    let llm_client = CompletionClient::new(llm_config).map_err(to_py_err)?;
+
+    let result = RUNTIME
+        .block_on(async {
+            if markdown {
+                enriched_chunk(&text_owned, &llm_client, &rust_config).await
+            } else {
+                enriched_chunk_plain(&text_owned, &llm_client, &rust_config).await
+            }
+        })
+        .map_err(to_py_err)?;
+
+    Ok(convert_result(result))
+}

--- a/packages/python/src/intent.rs
+++ b/packages/python/src/intent.rs
@@ -1,0 +1,209 @@
+//! Python bindings for intent-driven chunking.
+
+use pyo3::prelude::*;
+
+use cognigraph_chunker::embeddings::EmbeddingProvider;
+use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
+use cognigraph_chunker::semantic::intent_chunk::{
+    IntentConfig as RustIntentConfig, intent_chunk, intent_chunk_plain,
+};
+use cognigraph_chunker::semantic::intent_types::IntentType;
+
+use crate::error::to_py_err;
+use crate::semantic::RUNTIME;
+use crate::semantic::providers::{PyOllamaProvider, PyOnnxProvider, PyOpenAiProvider};
+
+/// Configuration for intent-driven chunking.
+#[pyclass(name = "IntentConfig", from_py_object)]
+#[derive(Clone)]
+pub struct PyIntentConfig {
+    #[pyo3(get, set)]
+    pub max_intents: usize,
+    #[pyo3(get, set)]
+    pub soft_budget: usize,
+    #[pyo3(get, set)]
+    pub hard_budget: usize,
+}
+
+#[pymethods]
+impl PyIntentConfig {
+    #[new]
+    #[pyo3(signature = (*, max_intents=20, soft_budget=512, hard_budget=768))]
+    fn new(max_intents: usize, soft_budget: usize, hard_budget: usize) -> Self {
+        Self {
+            max_intents,
+            soft_budget,
+            hard_budget,
+        }
+    }
+}
+
+impl From<&PyIntentConfig> for RustIntentConfig {
+    fn from(py: &PyIntentConfig) -> Self {
+        Self {
+            max_intents: py.max_intents,
+            soft_budget: py.soft_budget,
+            hard_budget: py.hard_budget,
+        }
+    }
+}
+
+/// A predicted user intent with matched chunk indices.
+#[pyclass(name = "PredictedIntent", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyPredictedIntent {
+    #[pyo3(get)]
+    pub query: String,
+    #[pyo3(get)]
+    pub intent_type: String,
+    #[pyo3(get)]
+    pub matched_chunks: Vec<usize>,
+}
+
+/// A chunk produced by intent-driven chunking.
+#[pyclass(name = "IntentChunk", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyIntentChunk {
+    #[pyo3(get)]
+    pub text: String,
+    #[pyo3(get)]
+    pub offset_start: usize,
+    #[pyo3(get)]
+    pub offset_end: usize,
+    #[pyo3(get)]
+    pub token_estimate: usize,
+    #[pyo3(get)]
+    pub best_intent: usize,
+    #[pyo3(get)]
+    pub alignment_score: f64,
+    #[pyo3(get)]
+    pub heading_path: Vec<String>,
+}
+
+/// Result of intent-driven chunking.
+#[pyclass(name = "IntentResult")]
+pub struct PyIntentResult {
+    #[pyo3(get)]
+    pub chunks: Vec<PyIntentChunk>,
+    #[pyo3(get)]
+    pub intents: Vec<PyPredictedIntent>,
+    #[pyo3(get)]
+    pub partition_score: f64,
+    #[pyo3(get)]
+    pub block_count: usize,
+}
+
+/// Run intent-driven chunking with a provider.
+#[pyfunction]
+#[pyo3(signature = (text, provider, api_key, base_url=None, model=None, config=None, *, markdown=true))]
+#[allow(clippy::too_many_arguments)]
+pub fn py_intent_chunk(
+    py: Python<'_>,
+    text: &str,
+    provider: &Bound<'_, PyAny>,
+    api_key: String,
+    base_url: Option<String>,
+    model: Option<String>,
+    config: Option<&PyIntentConfig>,
+    markdown: bool,
+) -> PyResult<PyIntentResult> {
+    let rust_config = config.map(RustIntentConfig::from).unwrap_or_default();
+    let text_owned = text.to_string();
+
+    let llm_config = LlmConfig::resolve(&Some(api_key), &base_url, &model).map_err(to_py_err)?;
+    let llm_client = CompletionClient::new(llm_config).map_err(to_py_err)?;
+
+    let _ = py;
+    if let Ok(p) = provider.cast::<PyOllamaProvider>() {
+        let provider_ref = p.borrow();
+        return run_intent(
+            &text_owned,
+            &provider_ref.inner,
+            &llm_client,
+            &rust_config,
+            markdown,
+        );
+    }
+    if let Ok(p) = provider.cast::<PyOpenAiProvider>() {
+        let provider_ref = p.borrow();
+        return run_intent(
+            &text_owned,
+            &provider_ref.inner,
+            &llm_client,
+            &rust_config,
+            markdown,
+        );
+    }
+    if let Ok(p) = provider.cast::<PyOnnxProvider>() {
+        let provider_ref = p.borrow();
+        return run_intent(
+            &text_owned,
+            &provider_ref.inner,
+            &llm_client,
+            &rust_config,
+            markdown,
+        );
+    }
+
+    Err(pyo3::exceptions::PyTypeError::new_err(
+        "provider must be OllamaProvider, OpenAiProvider, or OnnxProvider",
+    ))
+}
+
+fn run_intent<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: &CompletionClient,
+    config: &RustIntentConfig,
+    markdown: bool,
+) -> PyResult<PyIntentResult> {
+    let result = RUNTIME
+        .block_on(async {
+            if markdown {
+                intent_chunk(text, provider, llm_client, config).await
+            } else {
+                intent_chunk_plain(text, provider, llm_client, config).await
+            }
+        })
+        .map_err(to_py_err)?;
+
+    let chunks = result
+        .chunks
+        .into_iter()
+        .map(|c| PyIntentChunk {
+            text: c.text,
+            offset_start: c.offset_start,
+            offset_end: c.offset_end,
+            token_estimate: c.token_estimate,
+            best_intent: c.best_intent,
+            alignment_score: c.alignment_score,
+            heading_path: c.heading_path,
+        })
+        .collect();
+
+    let intents = result
+        .intents
+        .into_iter()
+        .map(|i| PyPredictedIntent {
+            query: i.query,
+            intent_type: intent_type_to_str(i.intent_type).to_string(),
+            matched_chunks: i.matched_chunks,
+        })
+        .collect();
+
+    Ok(PyIntentResult {
+        chunks,
+        intents,
+        partition_score: result.partition_score,
+        block_count: result.block_count,
+    })
+}
+
+fn intent_type_to_str(t: IntentType) -> &'static str {
+    match t {
+        IntentType::Factual => "factual",
+        IntentType::Procedural => "procedural",
+        IntentType::Conceptual => "conceptual",
+        IntentType::Comparative => "comparative",
+    }
+}

--- a/packages/python/src/lib.rs
+++ b/packages/python/src/lib.rs
@@ -1,10 +1,15 @@
+mod adaptive;
 mod chunker;
 mod cognitive;
+mod enriched;
 mod error;
+mod intent;
 mod merge;
+mod quality_metrics;
 mod semantic;
 mod signal;
 mod splitter;
+mod topo;
 
 use pyo3::prelude::*;
 
@@ -51,7 +56,45 @@ fn cognigraph_chunker(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<cognitive::PyCognitiveConfig>()?;
     m.add_class::<cognitive::PyCognitiveResult>()?;
     m.add_class::<cognitive::PyCognitiveChunk>()?;
+    m.add_class::<cognitive::PyRelationTriple>()?;
     m.add_function(wrap_pyfunction!(cognitive::py_cognitive_chunk, m)?)?;
+
+    // Intent-driven chunking
+    m.add_class::<intent::PyIntentConfig>()?;
+    m.add_class::<intent::PyIntentResult>()?;
+    m.add_class::<intent::PyIntentChunk>()?;
+    m.add_class::<intent::PyPredictedIntent>()?;
+    m.add_function(wrap_pyfunction!(intent::py_intent_chunk, m)?)?;
+
+    // Enriched chunking
+    m.add_class::<enriched::PyEnrichedConfig>()?;
+    m.add_class::<enriched::PyEnrichedResult>()?;
+    m.add_class::<enriched::PyEnrichedChunk>()?;
+    m.add_class::<enriched::PyTypedEntity>()?;
+    m.add_class::<enriched::PyMergeRecord>()?;
+    m.add_function(wrap_pyfunction!(enriched::py_enriched_chunk, m)?)?;
+
+    // Topology-aware chunking
+    m.add_class::<topo::PyTopoConfig>()?;
+    m.add_class::<topo::PyTopoResult>()?;
+    m.add_class::<topo::PyTopoChunk>()?;
+    m.add_class::<topo::PySectionClassification>()?;
+    m.add_function(wrap_pyfunction!(topo::py_topo_chunk, m)?)?;
+
+    // Quality metrics
+    m.add_class::<quality_metrics::PyMetricWeights>()?;
+    m.add_class::<quality_metrics::PyQualityMetrics>()?;
+    m.add_class::<quality_metrics::PyChunkForEval>()?;
+    m.add_class::<quality_metrics::PyMetricConfig>()?;
+    m.add_function(wrap_pyfunction!(quality_metrics::py_evaluate_chunks, m)?)?;
+
+    // Adaptive chunking
+    m.add_class::<adaptive::PyAdaptiveConfig>()?;
+    m.add_class::<adaptive::PyAdaptiveResult>()?;
+    m.add_class::<adaptive::PyAdaptiveReport>()?;
+    m.add_class::<adaptive::PyCandidateScore>()?;
+    m.add_class::<adaptive::PyScreeningDecision>()?;
+    m.add_function(wrap_pyfunction!(adaptive::py_adaptive_chunk, m)?)?;
 
     Ok(())
 }

--- a/packages/python/src/quality_metrics.rs
+++ b/packages/python/src/quality_metrics.rs
@@ -1,0 +1,223 @@
+//! Python bindings for quality metrics evaluation.
+
+use pyo3::prelude::*;
+
+use cognigraph_chunker::embeddings::EmbeddingProvider;
+use cognigraph_chunker::semantic::quality_metrics::{
+    ChunkForEval, MetricConfig, MetricWeights, QualityMetrics, evaluate_chunks,
+};
+
+use crate::error::to_py_err;
+use crate::semantic::RUNTIME;
+use crate::semantic::providers::{PyOllamaProvider, PyOnnxProvider, PyOpenAiProvider};
+
+// ── PyMetricWeights ───────────────────────────────────────────────────────────
+
+#[pyclass(name = "MetricWeights", from_py_object)]
+#[derive(Clone)]
+pub struct PyMetricWeights {
+    #[pyo3(get, set)]
+    pub sc: f64,
+    #[pyo3(get, set)]
+    pub icc: f64,
+    #[pyo3(get, set)]
+    pub dcc: f64,
+    #[pyo3(get, set)]
+    pub bi: f64,
+    #[pyo3(get, set)]
+    pub rc: f64,
+}
+
+#[pymethods]
+impl PyMetricWeights {
+    #[new]
+    #[pyo3(signature = (*, sc=0.20, icc=0.20, dcc=0.20, bi=0.20, rc=0.20))]
+    fn new(sc: f64, icc: f64, dcc: f64, bi: f64, rc: f64) -> Self {
+        Self {
+            sc,
+            icc,
+            dcc,
+            bi,
+            rc,
+        }
+    }
+}
+
+impl From<&PyMetricWeights> for MetricWeights {
+    fn from(py: &PyMetricWeights) -> Self {
+        Self {
+            sc: py.sc,
+            icc: py.icc,
+            dcc: py.dcc,
+            bi: py.bi,
+            rc: py.rc,
+        }
+    }
+}
+
+impl From<MetricWeights> for PyMetricWeights {
+    fn from(m: MetricWeights) -> Self {
+        Self {
+            sc: m.sc,
+            icc: m.icc,
+            dcc: m.dcc,
+            bi: m.bi,
+            rc: m.rc,
+        }
+    }
+}
+
+// ── PyQualityMetrics ──────────────────────────────────────────────────────────
+
+#[pyclass(name = "QualityMetrics", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyQualityMetrics {
+    #[pyo3(get)]
+    pub size_compliance: f64,
+    #[pyo3(get)]
+    pub intrachunk_cohesion: f64,
+    #[pyo3(get)]
+    pub contextual_coherence: f64,
+    #[pyo3(get)]
+    pub block_integrity: f64,
+    #[pyo3(get)]
+    pub reference_completeness: f64,
+    #[pyo3(get)]
+    pub composite: f64,
+}
+
+impl From<QualityMetrics> for PyQualityMetrics {
+    fn from(m: QualityMetrics) -> Self {
+        Self {
+            size_compliance: m.size_compliance,
+            intrachunk_cohesion: m.intrachunk_cohesion,
+            contextual_coherence: m.contextual_coherence,
+            block_integrity: m.block_integrity,
+            reference_completeness: m.reference_completeness,
+            composite: m.composite,
+        }
+    }
+}
+
+// ── PyChunkForEval ────────────────────────────────────────────────────────────
+
+#[pyclass(name = "ChunkForEval", from_py_object)]
+#[derive(Clone)]
+pub struct PyChunkForEval {
+    #[pyo3(get, set)]
+    pub text: String,
+    #[pyo3(get, set)]
+    pub offset_start: usize,
+    #[pyo3(get, set)]
+    pub offset_end: usize,
+}
+
+#[pymethods]
+impl PyChunkForEval {
+    #[new]
+    fn new(text: String, offset_start: usize, offset_end: usize) -> Self {
+        Self {
+            text,
+            offset_start,
+            offset_end,
+        }
+    }
+}
+
+impl From<&PyChunkForEval> for ChunkForEval {
+    fn from(py: &PyChunkForEval) -> Self {
+        Self {
+            text: py.text.clone(),
+            offset_start: py.offset_start,
+            offset_end: py.offset_end,
+        }
+    }
+}
+
+// ── PyMetricConfig ────────────────────────────────────────────────────────────
+
+#[pyclass(name = "MetricConfig", from_py_object)]
+#[derive(Clone)]
+pub struct PyMetricConfig {
+    #[pyo3(get, set)]
+    pub soft_budget: usize,
+    #[pyo3(get, set)]
+    pub hard_budget: usize,
+    #[pyo3(get, set)]
+    pub weights: Option<PyMetricWeights>,
+}
+
+#[pymethods]
+impl PyMetricConfig {
+    #[new]
+    #[pyo3(signature = (*, soft_budget=512, hard_budget=768, weights=None))]
+    fn new(soft_budget: usize, hard_budget: usize, weights: Option<PyMetricWeights>) -> Self {
+        Self {
+            soft_budget,
+            hard_budget,
+            weights,
+        }
+    }
+}
+
+impl From<&PyMetricConfig> for MetricConfig {
+    fn from(py: &PyMetricConfig) -> Self {
+        Self {
+            soft_budget: py.soft_budget,
+            hard_budget: py.hard_budget,
+            weights: py
+                .weights
+                .as_ref()
+                .map(MetricWeights::from)
+                .unwrap_or_default(),
+        }
+    }
+}
+
+// ── py_evaluate_chunks ────────────────────────────────────────────────────────
+
+/// Evaluate quality metrics for a set of chunks against the original text.
+#[pyfunction]
+#[pyo3(signature = (original_text, chunks, provider, config=None))]
+pub fn py_evaluate_chunks(
+    py: Python<'_>,
+    original_text: &str,
+    chunks: Vec<PyChunkForEval>,
+    provider: &Bound<'_, PyAny>,
+    config: Option<&PyMetricConfig>,
+) -> PyResult<PyQualityMetrics> {
+    let rust_config = config.map(MetricConfig::from).unwrap_or_default();
+    let rust_chunks: Vec<ChunkForEval> = chunks.iter().map(ChunkForEval::from).collect();
+    let text_owned = original_text.to_string();
+
+    let _ = py;
+    if let Ok(p) = provider.cast::<PyOllamaProvider>() {
+        let provider_ref = p.borrow();
+        return run_evaluate(&text_owned, &rust_chunks, &provider_ref.inner, &rust_config);
+    }
+    if let Ok(p) = provider.cast::<PyOpenAiProvider>() {
+        let provider_ref = p.borrow();
+        return run_evaluate(&text_owned, &rust_chunks, &provider_ref.inner, &rust_config);
+    }
+    if let Ok(p) = provider.cast::<PyOnnxProvider>() {
+        let provider_ref = p.borrow();
+        return run_evaluate(&text_owned, &rust_chunks, &provider_ref.inner, &rust_config);
+    }
+
+    Err(pyo3::exceptions::PyTypeError::new_err(
+        "provider must be OllamaProvider, OpenAiProvider, or OnnxProvider",
+    ))
+}
+
+fn run_evaluate<P: EmbeddingProvider>(
+    original_text: &str,
+    chunks: &[ChunkForEval],
+    provider: &P,
+    config: &MetricConfig,
+) -> PyResult<PyQualityMetrics> {
+    let metrics = RUNTIME
+        .block_on(async { evaluate_chunks(original_text, chunks, provider, config).await })
+        .map_err(to_py_err)?;
+
+    Ok(PyQualityMetrics::from(metrics))
+}

--- a/packages/python/src/topo.rs
+++ b/packages/python/src/topo.rs
@@ -1,0 +1,160 @@
+//! Python bindings for topology-aware chunking.
+
+use pyo3::prelude::*;
+
+use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
+use cognigraph_chunker::semantic::topo_chunk::{TopoConfig as RustTopoConfig, topo_chunk};
+use cognigraph_chunker::semantic::topo_types::{SectionClass, SectionClassification, TopoChunk};
+
+use crate::error::to_py_err;
+use crate::semantic::RUNTIME;
+
+/// Configuration for topology-aware chunking.
+#[pyclass(name = "TopoConfig", from_py_object)]
+#[derive(Clone)]
+pub struct PyTopoConfig {
+    #[pyo3(get, set)]
+    pub soft_budget: usize,
+    #[pyo3(get, set)]
+    pub hard_budget: usize,
+    #[pyo3(get, set)]
+    pub emit_sir: bool,
+}
+
+#[pymethods]
+impl PyTopoConfig {
+    #[new]
+    #[pyo3(signature = (*, soft_budget=512, hard_budget=768, emit_sir=false))]
+    fn new(soft_budget: usize, hard_budget: usize, emit_sir: bool) -> Self {
+        Self {
+            soft_budget,
+            hard_budget,
+            emit_sir,
+        }
+    }
+}
+
+impl From<&PyTopoConfig> for RustTopoConfig {
+    fn from(py: &PyTopoConfig) -> Self {
+        Self {
+            soft_budget: py.soft_budget,
+            hard_budget: py.hard_budget,
+            emit_sir: py.emit_sir,
+        }
+    }
+}
+
+/// A section classification returned to Python.
+#[pyclass(name = "SectionClassification", from_py_object)]
+#[derive(Clone)]
+pub struct PySectionClassification {
+    #[pyo3(get)]
+    pub section_id: usize,
+    #[pyo3(get)]
+    pub class: String,
+    #[pyo3(get)]
+    pub reason: String,
+}
+
+/// A topology-aware chunk returned to Python.
+#[pyclass(name = "TopoChunk", from_py_object)]
+#[derive(Clone)]
+pub struct PyTopoChunk {
+    #[pyo3(get)]
+    pub text: String,
+    #[pyo3(get)]
+    pub offset_start: usize,
+    #[pyo3(get)]
+    pub offset_end: usize,
+    #[pyo3(get)]
+    pub token_estimate: usize,
+    #[pyo3(get)]
+    pub heading_path: Vec<String>,
+    #[pyo3(get)]
+    pub section_classification: String,
+    #[pyo3(get)]
+    pub cross_references: Vec<usize>,
+}
+
+/// Result of topology-aware chunking.
+#[pyclass(name = "TopoResult")]
+pub struct PyTopoResult {
+    #[pyo3(get)]
+    pub chunks: Vec<PyTopoChunk>,
+    #[pyo3(get)]
+    pub classifications: Vec<PySectionClassification>,
+    #[pyo3(get)]
+    pub block_count: usize,
+    #[pyo3(get)]
+    pub sir_json: Option<String>,
+}
+
+fn section_class_to_str(class: SectionClass) -> &'static str {
+    match class {
+        SectionClass::Atomic => "atomic",
+        SectionClass::Splittable => "splittable",
+        SectionClass::MergeCandidate => "merge_candidate",
+    }
+}
+
+fn convert_chunk(c: TopoChunk) -> PyTopoChunk {
+    PyTopoChunk {
+        text: c.text,
+        offset_start: c.offset_start,
+        offset_end: c.offset_end,
+        token_estimate: c.token_estimate,
+        heading_path: c.heading_path,
+        section_classification: c.section_classification,
+        cross_references: c.cross_references,
+    }
+}
+
+fn convert_classification(sc: SectionClassification) -> PySectionClassification {
+    PySectionClassification {
+        section_id: sc.section_id,
+        class: section_class_to_str(sc.class).to_string(),
+        reason: sc.reason,
+    }
+}
+
+/// Run topology-aware chunking.
+#[pyfunction]
+#[pyo3(signature = (text, api_key, base_url=None, model=None, config=None))]
+pub fn py_topo_chunk(
+    _py: Python<'_>,
+    text: &str,
+    api_key: String,
+    base_url: Option<String>,
+    model: Option<String>,
+    config: Option<&PyTopoConfig>,
+) -> PyResult<PyTopoResult> {
+    let rust_config = config.map(RustTopoConfig::from).unwrap_or_default();
+    let text_owned = text.to_string();
+
+    let llm_config = LlmConfig::resolve(&Some(api_key), &base_url, &model).map_err(to_py_err)?;
+    let llm_client = CompletionClient::new(llm_config).map_err(to_py_err)?;
+
+    let result = RUNTIME
+        .block_on(async { topo_chunk(&text_owned, &llm_client, &rust_config).await })
+        .map_err(to_py_err)?;
+
+    let sir_json = if rust_config.emit_sir {
+        serde_json::to_string(&result.sir).ok()
+    } else {
+        None
+    };
+
+    let chunks = result.chunks.into_iter().map(convert_chunk).collect();
+    let classifications = result
+        .classifications
+        .into_iter()
+        .map(convert_classification)
+        .collect();
+
+    Ok(PyTopoResult {
+        chunks,
+        classifications,
+        block_count: result.block_count,
+        sir_json,
+    })
+}


### PR DESCRIPTION
## Summary

Brings `packages/python` up to parity with the Rust crate. All 4 new chunking methods (intent, enriched, topo, adaptive) and the quality metrics module are now available from Python.

### Changes
- **Dependencies**: bumped tokio 1.49 → 1.51, added serde_json 1.0
- **5 new source files**: `intent.rs`, `enriched.rs`, `topo.rs`, `adaptive.rs`, `quality_metrics.rs`
- **lib.rs**: registered 19 new pyclasses and 5 new pyfunctions

### New Python exports
- Intent: `IntentConfig`, `IntentResult`, `IntentChunk`, `PredictedIntent`, `py_intent_chunk`
- Enriched: `EnrichedConfig`, `EnrichedResult`, `EnrichedChunk`, `TypedEntity`, `MergeRecord`, `py_enriched_chunk`
- Topo: `TopoConfig`, `TopoResult`, `TopoChunk`, `SectionClassification`, `py_topo_chunk`
- Adaptive: `AdaptiveConfig`, `AdaptiveResult`, `AdaptiveReport`, `CandidateScore`, `ScreeningDecision`, `py_adaptive_chunk`
- Quality metrics: `MetricWeights`, `QualityMetrics`, `ChunkForEval`, `MetricConfig`, `py_evaluate_chunks`

All output-only pyclasses use `skip_from_py_object` to silence PyO3 0.28 deprecation warnings while keeping `Clone`.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --all` — 149 tests pass, zero regressions
- [x] `maturin build --release -i python3.13` — wheel built successfully
- [x] Installed wheel in fresh venv — all 53 exports importable
- [x] End-to-end `py_enriched_chunk` on real forensics report — 9 chunks, 2 semantic keys (same result as CLI)
- [x] End-to-end `py_adaptive_chunk` with semantic+cognitive candidates — cognitive wins with composite 0.689 (same result as CLI)