### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "cognigraph-chunker"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "packages/python"]
 
 [package]
 name = "cognigraph-chunker"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 license = "MIT"
 


### PR DESCRIPTION
## Summary

Version bump for the `cognigraph-chunker` main crate: `2.0.0` → `2.1.0`.

This reflects the additive features shipped in PR #22 (merged into develop):
- 4 new chunking methods: intent, enriched, topology-aware, adaptive
- Standalone quality metrics module with 5 intrinsic metrics
- New API endpoints: `/intent`, `/enriched`, `/topo`, `/adaptive`, `/evaluate`
- 4 new CLI subcommands
- Dependency updates (clap 4.6, tokio 1.51, unicode-segmentation 1.13, pulldown-cmark 0.13.3)

Semver rationale: all changes are additive — no existing API changed, no existing behavior changed — so this is a MINOR bump.

The Python package is being bumped separately (0.1.0 → 0.2.0) in #23.

## Test plan

- [x] `cargo check` — clean
- [x] Cargo.lock updated