### PR TITLE
Release v2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,9 +1735,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "libc",
  "once_cell",
@@ -1749,18 +1749,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1768,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1780,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "cognigraph-chunker"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -93,7 +93,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.66"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
 dependencies = [
  "clap",
 ]
@@ -675,7 +675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2037,7 +2037,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2094,7 +2094,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2399,7 +2399,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2967,7 +2967,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2665,9 +2665,9 @@ checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
  "bitflags",
  "getopts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1232,9 +1232,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -1337,9 +1337,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1844,7 +1844,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2037,7 +2037,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2094,7 +2094,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2276,12 +2276,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2399,7 +2399,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2513,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -2530,9 +2530,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2967,7 +2967,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3031,15 +3031,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3071,28 +3062,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3108,12 +3082,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,12 +3092,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3144,22 +3106,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3174,12 +3124,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3190,12 +3134,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3210,12 +3148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3226,12 +3158,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,12 +388,13 @@ dependencies = [
 
 [[package]]
 name = "cognigraph-python"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cognigraph-chunker",
  "numpy",
  "pyo3",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -82,7 +82,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -93,7 +93,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -116,9 +116,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "406e68b4de5c59cfb8f750a7cbd4d31ae153788b8352167c1e5f4fc26e8c91e9"
 dependencies = [
  "clap",
 ]
@@ -347,15 +347,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -430,13 +430,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
@@ -585,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "pem-rfc7468",
  "zeroize",
@@ -675,7 +674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -689,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -811,20 +810,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -872,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -935,9 +934,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -950,7 +949,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -999,12 +997,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1012,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1025,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1039,15 +1038,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1059,15 +1058,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1113,12 +1112,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1138,15 +1137,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1178,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -1191,7 +1190,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1200,9 +1199,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1216,10 +1237,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1254,9 +1277,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1455,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1495,9 +1518,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1527,9 +1550,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -1603,9 +1626,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -1618,21 +1641,15 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -1670,18 +1687,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1844,7 +1861,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1863,10 +1880,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1962,9 +1985,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2023,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -2037,14 +2060,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2094,7 +2117,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2105,9 +2128,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2138,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2176,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2391,15 +2414,15 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2444,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2464,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2701,9 +2724,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "der",
@@ -2713,15 +2736,15 @@ dependencies = [
  "rustls-pki-types",
  "socks",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-root-certs",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
  "http",
@@ -2742,10 +2765,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -2816,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2829,23 +2852,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.61"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2853,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2866,9 +2885,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -2909,9 +2928,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.88"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2967,7 +2986,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3031,6 +3050,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3062,11 +3090,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3082,6 +3127,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,6 +3143,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3106,10 +3163,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3124,6 +3193,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3134,6 +3209,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3148,6 +3229,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,6 +3245,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -3249,15 +3342,15 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3266,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3278,18 +3371,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3298,18 +3391,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3325,9 +3418,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3336,9 +3429,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3347,9 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -69,9 +69,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -82,7 +82,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -93,7 +93,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -675,7 +675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1849,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2037,7 +2037,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2094,7 +2094,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2399,7 +2399,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2967,7 +2967,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,15 @@ memchr = "2.8"
 daggrs = "0.1"
 
 # CLI
-clap = { version = "4.5", features = ["derive"] }
-clap_complete = "4.5"
+clap = { version = "4.6", features = ["derive"] }
+clap_complete = "4.6"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Async runtime
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.51", features = ["full"] }
 
 # HTTP client (embedding providers)
 reqwest = { version = "0.13", features = ["json", "form"] }
@@ -44,7 +44,7 @@ tokenizers = "0.22"
 ndarray = "0.17"
 
 # Unicode sentence segmentation
-unicode-segmentation = "1.12"
+unicode-segmentation = "1.13"
 
 # Language detection
 whatlang = "0.18"
@@ -53,7 +53,7 @@ whatlang = "0.18"
 unicode-script = "0.5"
 
 # Markdown AST parsing
-pulldown-cmark = "0.13"
+pulldown-cmark = "0.13.3"
 
 # Web framework
 axum = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "packages/python"]
 
 [package]
 name = "cognigraph-chunker"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # cognigraph-chunker
 
-Fast text chunking toolkit with fixed-size, delimiter-based, semantic, and cognition-aware strategies.
+Fast text chunking toolkit with fixed-size, delimiter-based, semantic, cognition-aware, intent-driven, topology-aware, enriched, and adaptive strategies.
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## Features
 
-- **Four chunking strategies** -- fixed-size with delimiter-aware boundaries, delimiter/pattern splitting, embedding-based semantic chunking, and cognition-aware chunking with multi-signal boundary scoring
+- **Eight chunking strategies** -- fixed-size, delimiter/pattern splitting, semantic, cognition-aware, intent-driven, topology-aware, enriched, and adaptive (auto-selecting)
 - **Cognition-aware chunking** -- 8-signal boundary scoring (semantic similarity, entity continuity, discourse continuation, heading context, structural affinity, topic shift, orphan risk, budget pressure), proposition-aware healing, cross-chunk entity tracking, and automatic quality metrics
+- **Intent-driven chunking** -- boundaries optimized for predicted user queries using LLM intent generation, embedding alignment, and dynamic programming for globally optimal partitions
+- **Topology-aware chunking** -- builds a Structured Intermediate Representation (SIR) tree from heading hierarchy, then uses dual LLM agents (Inspector + Refiner) to produce structure-preserving chunks
+- **Enriched chunking** -- single LLM call per chunk extracts 7 metadata fields (title, summary, keywords, typed entities, hypothetical questions, semantic keys, category), followed by semantic-key-based recombination
+- **Adaptive chunking** -- meta-router that runs candidate methods, scores output with 5 intrinsic quality metrics (size compliance, intrachunk cohesion, contextual coherence, block integrity, reference completeness), and returns the best result
 - **Multilingual** -- automatic language detection across 70+ languages with language-specific enrichment for 14 language groups (English, German, French, Spanish, Portuguese, Italian, Dutch, Russian, Turkish, Polish, Chinese, Japanese, Korean, Arabic)
+- **Quality metrics module** -- standalone 5-metric evaluation (SC, ICC, DCC, BI, RC) usable for benchmarking any chunking output via API or CI assertions
 - **Four interfaces** -- CLI tool, REST API (Axum), Python bindings (PyO3), and Docker
 - **Five embedding providers** -- OpenAI, Ollama, ONNX Runtime (local), Cloudflare Workers AI, and OAuth-authenticated OpenAI-compatible endpoints
 - **Markdown-aware** -- parses markdown AST to preserve tables, code blocks, headings, and lists as atomic units
@@ -17,6 +22,19 @@ Fast text chunking toolkit with fixed-size, delimiter-based, semantic, and cogni
 - **Ambiguous boundary refinement** -- optional cross-encoder reranking for precision improvement on uncertain boundaries (NVIDIA NIM, Cohere, Cloudflare Workers AI, OAuth-authenticated endpoints, or local ONNX)
 - **Merge post-processing** -- combine small chunks into token-budget groups across all strategies
 - **Output formats** -- plain text, JSON, and JSONL
+
+## Methods at a Glance
+
+| Method | CLI Command | LLM Required | Embedding Required | Key Strength |
+|--------|-------------|--------------|-------------------|--------------|
+| Fixed-size | `chunk` | No | No | Fast, predictable chunk sizes |
+| Delimiter split | `split` | No | No | Precise boundary control |
+| Semantic | `semantic` | No | Yes | Topic-boundary detection |
+| Cognitive | `cognitive` | Optional | Yes | Entity/discourse preservation |
+| Intent-driven | `intent` | Yes | Yes | Retrieval-optimized boundaries |
+| Topology-aware | `topo` | Yes | No | Hierarchical structure preservation |
+| Enriched | `enriched` | Yes | No | Self-describing chunks with metadata |
+| Adaptive | `adaptive` | Depends | Yes | Auto-selects best method per document |
 
 ## Installation
 
@@ -64,6 +82,18 @@ cognigraph-chunker cognitive -i document.md --graph
 
 # Cognitive chunking with LLM-based relation extraction
 cognigraph-chunker cognitive -i document.md --relations -f json
+
+# Intent-driven chunking (boundaries optimized for retrieval)
+cognigraph-chunker intent -i document.md -p openai --api-key $OPENAI_API_KEY
+
+# Topology-aware chunking (preserves heading hierarchy)
+cognigraph-chunker topo -i document.md --api-key $OPENAI_API_KEY
+
+# Enriched chunking (7 metadata fields per chunk)
+cognigraph-chunker enriched -i document.md --api-key $OPENAI_API_KEY
+
+# Adaptive chunking (auto-selects best method)
+cognigraph-chunker adaptive -i document.md -p openai --api-key $OPENAI_API_KEY
 ```
 
 ### REST API
@@ -321,6 +351,137 @@ cognigraph-chunker cognitive -i doc.md --emit-signals --stats -f json
 cognigraph-chunker cognitive -i doc.md --no-markdown
 ```
 
+### `intent` -- Intent-driven chunking
+
+Split text with boundaries optimized for predicted user queries using LLM intent generation and dynamic programming.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--input` | `-i` | `-` (stdin) | Input file path, or `-` for stdin |
+| `--provider` | `-p` | `ollama` | Embedding provider: `ollama`, `openai`, `onnx`, `cloudflare`, `oauth` |
+| `--model` | `-m` | provider default | Embedding model name |
+| `--api-key` | | none | API key for LLM and OpenAI embeddings |
+| `--base-url` | | none | Base URL override for the embedding API |
+| `--intent-model` | | `gpt-4.1-mini` | LLM model for intent generation |
+| `--llm-base-url` | | `https://api.openai.com/v1` | LLM endpoint URL |
+| `--max-intents` | | 20 | Maximum number of intents to generate |
+| `--soft-budget` | | 512 | Target tokens per chunk |
+| `--hard-budget` | | 768 | Maximum tokens per chunk |
+| `--format` | `-f` | plain | Output format: `plain`, `json`, `jsonl` |
+| `--merge` | | off | Post-process by merging small chunks |
+| `--chunk-size` | | 512 | Target token count per merged chunk |
+
+**Examples:**
+
+```sh
+# Intent-driven chunking with OpenAI
+cognigraph-chunker intent -i doc.md -p openai --api-key $KEY
+
+# More intents for a long document
+cognigraph-chunker intent -i doc.md -p openai --api-key $KEY --max-intents 30
+
+# Smaller chunks
+cognigraph-chunker intent -i doc.md -p openai --api-key $KEY \
+  --soft-budget 256 --hard-budget 512 -f json
+```
+
+### `topo` -- Topology-aware chunking
+
+Split text by building a Structured Intermediate Representation (SIR) from heading hierarchy, then using dual LLM agents to classify and partition sections.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--input` | `-i` | `-` (stdin) | Input file path, or `-` for stdin |
+| `--api-key` | | none | API key for LLM |
+| `--topo-model` | | `gpt-4.1-mini` | LLM model for Inspector and Refiner agents |
+| `--llm-base-url` | | `https://api.openai.com/v1` | LLM endpoint URL |
+| `--soft-budget` | | 512 | Target tokens per chunk |
+| `--hard-budget` | | 768 | Maximum tokens per chunk |
+| `--format` | `-f` | plain | Output format: `plain`, `json`, `jsonl` |
+| `--emit-sir` | | off | Include SIR structure in JSON output |
+
+**Examples:**
+
+```sh
+# Topology-aware chunking
+cognigraph-chunker topo -i doc.md --api-key $KEY
+
+# Include SIR in output
+cognigraph-chunker topo -i doc.md --api-key $KEY -f json --emit-sir
+
+# Custom model and budgets
+cognigraph-chunker topo -i doc.md --api-key $KEY \
+  --topo-model gpt-4.1-mini --soft-budget 256 --hard-budget 512
+```
+
+### `enriched` -- Enriched chunking
+
+Structure-preserving chunking with single-call LLM enrichment (7 metadata fields per chunk) and semantic-key-based recombination.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--input` | `-i` | `-` (stdin) | Input file path, or `-` for stdin |
+| `--api-key` | | none | API key for LLM |
+| `--enrichment-model` | | `gpt-4.1-mini` | LLM model for enrichment |
+| `--llm-base-url` | | `https://api.openai.com/v1` | LLM endpoint URL |
+| `--soft-budget` | | 512 | Target tokens per chunk |
+| `--hard-budget` | | 768 | Maximum tokens per chunk |
+| `--no-recombine` | | off | Skip key-based recombination step |
+| `--no-re-enrich` | | off | Skip re-enrichment of merged chunks |
+| `--format` | `-f` | plain | Output format: `plain`, `json`, `jsonl` |
+
+**Examples:**
+
+```sh
+# Enriched chunking with metadata
+cognigraph-chunker enriched -i doc.md --api-key $KEY
+
+# Metadata only, no recombination
+cognigraph-chunker enriched -i doc.md --api-key $KEY --no-recombine
+
+# JSON output
+cognigraph-chunker enriched -i doc.md --api-key $KEY -f json
+```
+
+### `adaptive` -- Adaptive chunking
+
+Meta-router that runs candidate methods, scores output with 5 quality metrics, and returns the best result.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--input` | `-i` | `-` (stdin) | Input file path, or `-` for stdin |
+| `--provider` | `-p` | `ollama` | Embedding provider (for metrics + embedding-based candidates) |
+| `--model` | `-m` | provider default | Embedding model name |
+| `--api-key` | | none | API key for LLM and OpenAI embeddings |
+| `--base-url` | | none | Base URL override for the embedding API |
+| `--llm-base-url` | | `https://api.openai.com/v1` | LLM endpoint URL |
+| `--llm-model` | | `gpt-4.1-mini` | LLM model for LLM-based candidates |
+| `--candidates` | | `semantic,cognitive,intent,enriched,topo` | Comma-separated method names to evaluate |
+| `--force-candidates` | | off | Bypass pre-screening heuristics |
+| `--metric-weights` | | equal (0.20 each) | Metric weights as `key=value` pairs |
+| `--soft-budget` | | 512 | Target tokens per chunk |
+| `--hard-budget` | | 768 | Maximum tokens per chunk |
+| `--format` | `-f` | plain | Output format: `plain`, `json`, `jsonl` |
+| `--report` | | off | Include quality report in output (JSON only) |
+
+**Examples:**
+
+```sh
+# Adaptive chunking with all candidates
+cognigraph-chunker adaptive -i doc.md -p openai --api-key $KEY
+
+# Restrict candidates
+cognigraph-chunker adaptive -i doc.md -p openai --api-key $KEY \
+  --candidates semantic,cognitive,intent
+
+# Custom metric weights
+cognigraph-chunker adaptive -i doc.md -p openai --api-key $KEY \
+  --metric-weights sc=0.10,icc=0.30,dcc=0.15,bi=0.15,rc=0.30
+
+# Include quality report
+cognigraph-chunker adaptive -i doc.md -p openai --api-key $KEY -f json --report
+```
+
 ### `serve` -- REST API server
 
 Start an HTTP server exposing all chunking operations.
@@ -552,6 +713,178 @@ Cognition-aware chunking with multi-signal boundary scoring.
     { "source": 0, "target": 3, "edge_type": "entity", "entity": "CogniGraph" }
   ],
   "metadata": { "node_count": 5, "edge_count": 12 }
+}
+```
+
+### `POST /api/v1/intent`
+
+Intent-driven chunking with retrieval-optimized boundaries.
+
+**Request body:**
+```json
+{
+  "text": "string (required)",
+  "provider": "openai",
+  "model": null,
+  "api_key": null,
+  "base_url": null,
+  "intent_model": "gpt-4.1-mini",
+  "max_intents": 20,
+  "soft_budget": 512,
+  "hard_budget": 768
+}
+```
+
+- `intent_model`: LLM for generating hypothetical queries (default: `gpt-4.1-mini`)
+- `max_intents`: number of intents to generate (default: 20)
+- All embedding provider fields work the same as `/api/v1/semantic`
+
+**Response:**
+```json
+{
+  "chunks": [
+    { "text": "...", "offset_start": 0, "offset_end": 1234, "token_estimate": 450, "best_intent": 2, "alignment_score": 0.87, "heading_path": ["Introduction"] }
+  ],
+  "intents": [
+    { "query": "What are the side effects?", "intent_type": "factual", "matched_chunks": [3, 7] }
+  ],
+  "partition_score": 0.82,
+  "count": 12
+}
+```
+
+### `POST /api/v1/topo`
+
+Topology-aware chunking with SIR and dual-agent refinement.
+
+**Request body:**
+```json
+{
+  "text": "string (required)",
+  "topo_model": "gpt-4.1-mini",
+  "soft_budget": 512,
+  "hard_budget": 768,
+  "emit_sir": false
+}
+```
+
+- `topo_model`: LLM for Inspector and Refiner agents (default: `gpt-4.1-mini`)
+- `emit_sir`: include the SIR structure in the response
+
+**Response:**
+```json
+{
+  "chunks": [
+    { "text": "...", "offset_start": 0, "offset_end": 2048, "token_estimate": 480, "heading_path": ["Methods", "Data Collection"], "section_classification": "atomic", "cross_references": [4] }
+  ],
+  "count": 8
+}
+```
+
+### `POST /api/v1/enriched`
+
+Enriched chunking with 7 metadata fields and key-based recombination.
+
+**Request body:**
+```json
+{
+  "text": "string (required)",
+  "enrichment_model": "gpt-4.1-mini",
+  "soft_budget": 512,
+  "hard_budget": 768,
+  "recombine": true,
+  "re_enrich": true
+}
+```
+
+- `enrichment_model`: LLM for metadata extraction (default: `gpt-4.1-mini`)
+- `recombine`: enable key-based recombination (default: true)
+- `re_enrich`: re-enrich merged chunks (default: true)
+
+**Response:**
+```json
+{
+  "chunks": [
+    { "text": "...", "title": "...", "summary": "...", "keywords": [...], "typed_entities": [...], "hypothetical_questions": [...], "semantic_keys": [...], "category": "...", "heading_path": [...] }
+  ],
+  "key_dictionary": { "xr-7742-dosing": [0, 3] },
+  "count": 10
+}
+```
+
+### `POST /api/v1/adaptive`
+
+Adaptive chunking: runs candidate methods, scores with quality metrics, returns the best.
+
+**Request body:**
+```json
+{
+  "text": "string (required)",
+  "provider": "openai",
+  "model": null,
+  "api_key": null,
+  "candidates": ["semantic", "cognitive", "intent", "enriched", "topo"],
+  "soft_budget": 512,
+  "hard_budget": 768,
+  "metric_weights": { "sc": 0.20, "icc": 0.20, "dcc": 0.20, "bi": 0.20, "rc": 0.20 },
+  "include_report": true
+}
+```
+
+- `candidates`: methods to evaluate (default: all five)
+- `metric_weights`: custom weights for the composite score (default: equal)
+- `include_report`: include per-candidate quality metrics in the response
+- All embedding provider fields work the same as `/api/v1/semantic`
+
+**Response:**
+```json
+{
+  "winner": "cognitive",
+  "chunks": [ ... ],
+  "count": 12,
+  "report": {
+    "candidates": [
+      { "method": "semantic", "metrics": { "size_compliance": 0.85, "intrachunk_cohesion": 0.72, "contextual_coherence": 0.68, "block_integrity": 0.90, "reference_completeness": 0.65, "composite": 0.76 }, "chunk_count": 15 },
+      { "method": "cognitive", "metrics": { "size_compliance": 0.92, "intrachunk_cohesion": 0.78, "contextual_coherence": 0.71, "block_integrity": 0.95, "reference_completeness": 0.88, "composite": 0.85 }, "chunk_count": 12 }
+    ],
+    "pre_screening": [
+      { "method": "topo", "included": false, "reason": "Document has < 2 heading levels" }
+    ]
+  }
+}
+```
+
+### `POST /api/v1/evaluate`
+
+Evaluate pre-chunked output with the 5 quality metrics (standalone, works with any chunking method).
+
+**Request body:**
+```json
+{
+  "text": "string (required, original document)",
+  "chunks": [
+    { "text": "...", "offset_start": 0, "offset_end": 1024 }
+  ],
+  "provider": "openai",
+  "model": null,
+  "api_key": null,
+  "soft_budget": 512,
+  "hard_budget": 768,
+  "metric_weights": { "sc": 0.20, "icc": 0.20, "dcc": 0.20, "bi": 0.20, "rc": 0.20 }
+}
+```
+
+**Response:**
+```json
+{
+  "metrics": {
+    "size_compliance": 0.90,
+    "intrachunk_cohesion": 0.78,
+    "contextual_coherence": 0.72,
+    "block_integrity": 0.95,
+    "reference_completeness": 0.85,
+    "composite": 0.84
+  }
 }
 ```
 
@@ -919,10 +1252,16 @@ cognigraph-chunker/
     semantic/           # Semantic and cognitive chunking pipelines
       enrichment/       # Cognitive enrichment (entities, discourse, heading context, language)
       cognitive_*.rs    # Cognitive scoring, assembly, and reranking
+      intent_chunk.rs   # Intent-driven DP alignment pipeline
+      topo_chunk.rs     # Topology-aware SIR + dual-agent pipeline
+      enriched_chunk.rs # Enriched chunking with key-based recombination
+      adaptive_chunk.rs # Adaptive meta-router and candidate scoring
+      quality_metrics.rs # 5 intrinsic quality metrics (standalone)
+      sir.rs            # Structured Intermediate Representation (SIR)
       proposition_heal.rs # Proposition-aware chunk healing
       graph_export.rs   # Graph export format (nodes + edges)
-      evaluation.rs     # Quality metrics
-    llm/                # LLM integration (relation extraction, synopsis generation)
+      evaluation.rs     # Cognitive evaluation metrics
+    llm/                # LLM integration (intents, enrichment, topo agents, relations, synopsis)
     api/                # REST API (Axum handlers, types, middleware)
     cli/                # CLI subcommands and options
     output/             # Output formatting (plain, json, jsonl)
@@ -933,6 +1272,8 @@ cognigraph-chunker/
 The core algorithms operate on byte slices for zero-copy performance. The semantic pipeline splits text into blocks (markdown-aware or sentence-based), computes embeddings, calculates cross-similarity distances, applies Savitzky-Golay smoothing, and detects topic boundaries at local minima.
 
 The cognitive pipeline extends this with block-level enrichment (entity detection, discourse markers, heading context, continuation flags), weighted multi-signal boundary scoring, valley-based assembly with soft/hard token budgets, and proposition-aware healing that merges chunks with broken cross-references. Language detection runs automatically, selecting appropriate heuristics for 14 language groups.
+
+Four additional methods address specialized use cases: intent-driven chunking uses LLM-generated hypothetical queries and dynamic programming to optimize boundaries for retrieval; topology-aware chunking builds a SIR tree from heading hierarchy and uses dual LLM agents for structure-preserving partitioning; enriched chunking extracts 7 metadata fields per chunk via single LLM calls and recombines chunks sharing semantic keys; adaptive chunking runs multiple candidates and selects the best using 5 intrinsic quality metrics.
 
 ## License
 

--- a/docs/06-cognigraph-chunker-putting-it-all-together.md
+++ b/docs/06-cognigraph-chunker-putting-it-all-together.md
@@ -2,45 +2,122 @@
 
 The previous five articles explored the concepts behind text chunking: why it matters for AI retrieval, how fixed-size and delimiter strategies handle structural boundaries, how semantic analysis detects topic shifts using signal processing, how markdown-aware parsing preserves document structure, and how token-aware merging normalizes chunk sizes. CogniGraph Chunker is the toolkit that brings all of these ideas into a single, production-ready package.
 
-## One library, three strategies
+## One library, eight strategies
 
-CogniGraph Chunker implements all three chunking strategies from a shared core. Fixed-size chunking with delimiter-aware boundaries, delimiter and pattern splitting with Aho-Corasick multi-pattern matching, and semantic chunking with embedding-based topic boundary detection all live in the same codebase, share the same output format, and can all be followed by token-aware merging as a post-processing step.
+CogniGraph Chunker implements eight chunking strategies from a shared core. They range from byte-level splitting to an adaptive meta-router that picks the best method automatically. All eight share the same output format, the same interfaces, and can all be followed by token-aware merging as a post-processing step.
 
-This matters in practice because most teams start with fixed-size chunking, realize they need better boundary detection, move to delimiter splitting, and eventually adopt semantic chunking for their most important use cases. Having all three in one toolkit means you can experiment with strategies without changing your infrastructure — just swap a subcommand or an API parameter.
+This matters in practice because most teams start with fixed-size chunking, realize they need better boundary detection, move to delimiter splitting, and eventually adopt one of the more sophisticated strategies for their most important use cases. Having all eight in one toolkit means you can experiment with strategies without changing your infrastructure -- just swap a subcommand or an API parameter.
+
+### Fixed-size chunking
+
+The simplest strategy. Set a target size in bytes or characters, and the chunker walks through the text producing chunks of that size with delimiter-aware boundaries. Fast, predictable, zero configuration. Use it when uniformity matters more than coherence.
+
+```sh
+cognigraph-chunker chunk -i document.md -s 1024
+```
+
+### Delimiter splitting
+
+Split at every occurrence of a delimiter -- sentence-ending punctuation, newlines, custom patterns. Multi-pattern matching uses an Aho-Corasick automaton compiled once and reused. Combine with token-aware merging to group short sentences into right-sized chunks.
+
+```sh
+cognigraph-chunker split -i document.md -d ".?!" --merge --chunk-size 256
+```
+
+### Semantic chunking
+
+The first strategy that understands content. Each block gets an embedding vector, and the pipeline computes cosine similarity between adjacent blocks. A Savitzky-Golay filter smooths the similarity curve, and local minima become split points. Where similarity drops, topics change.
+
+```sh
+cognigraph-chunker semantic -i document.md --provider ollama
+```
+
+### Cognitive chunking
+
+Extends semantic chunking with eight signals instead of one. Beyond embedding similarity, the boundary scorer evaluates entity continuity, discourse continuation, heading context, structural affinity, topic shift, orphan risk, and budget pressure. Blocks are enriched with named entities, pronouns, demonstratives, discourse markers, and heading ancestry before scoring. The result is chunks that preserve not just topics but propositions -- the "who did what to whom" structure that makes text retrievable and answerable. Supports 14 language groups, optional cross-encoder reranking on ambiguous boundaries, LLM-based relation extraction, and graph export.
+
+```sh
+cognigraph-chunker cognitive -i document.md --provider ollama
+```
+
+### Intent-driven chunking
+
+Optimizes boundaries for predicted user queries rather than topic transitions. An LLM generates hypothetical queries that users might ask about the document. Each candidate chunk is scored by how well its embedding aligns with the predicted intents. Dynamic programming finds the globally optimal partition -- unlike greedy approaches, the DP evaluates downstream consequences of every boundary decision. The result is chunks that align with how readers search, not how authors organize. See [Article 10](10-intent-driven-chunking.md) for full details.
+
+```sh
+cognigraph-chunker intent -i document.md -p openai --api-key $OPENAI_API_KEY
+```
+
+### Enriched chunking
+
+Produces self-describing chunks. Each chunk carries seven metadata fields extracted in a single LLM call: title, summary, keywords, typed entities, hypothetical questions, semantic keys, and category. The semantic keys create explicit concept links between chunks -- when two chunks discuss the same topic, the LLM assigns matching keys. A recombination step merges chunks sharing the same keys. No embedding provider is needed. See [Article 12](12-enriched-chunking.md) for full details.
+
+```sh
+cognigraph-chunker enriched -i document.md --api-key $OPENAI_API_KEY
+```
+
+### Topology-aware chunking
+
+Builds a Structured Intermediate Representation (SIR) -- a tree mirroring the document's heading hierarchy with content blocks as leaves and cross-reference edges. Two LLM agents then classify and partition sections: the Inspector labels sections as atomic, splittable, or merge candidates; the Refiner determines optimal split points and merge directions. The result respects heading structure, cross-section dependencies, and structural coupling that flat methods miss. No embedding provider is needed. See [Article 11](11-topology-aware-chunking.md) for full details.
+
+```sh
+cognigraph-chunker topo -i document.md --api-key $OPENAI_API_KEY
+```
+
+### Adaptive chunking
+
+A meta-router that runs multiple candidate methods on the same document, scores each with five intrinsic quality metrics (Size Compliance, Intrachunk Cohesion, Contextual Coherence, Block Integrity, Reference Completeness), and returns the output from the highest-scoring method. Pre-screening heuristics skip methods unlikely to help for a given document. Use it when you process diverse document types and cannot predict which method works best. See [Article 13](13-adaptive-chunking.md) for full details.
+
+```sh
+cognigraph-chunker adaptive -i document.md -p openai --api-key $OPENAI_API_KEY \
+  --candidates semantic,cognitive,intent
+```
 
 ## Four interfaces
 
 The same algorithms are exposed through four interfaces, each suited to a different workflow.
 
-The **CLI** is the fastest way to experiment. Pipe a document through `cognigraph-chunker semantic -i doc.md` and see the chunks immediately. Adjust parameters like `--threshold` and `--sg-window` interactively until the output looks right. Export to JSON or JSONL for downstream processing. The CLI reads from files or stdin, so it slots into shell pipelines naturally.
+The **CLI** is the fastest way to experiment. Pipe a document through any subcommand (`chunk`, `split`, `semantic`, `cognitive`, `intent`, `enriched`, `topo`, `adaptive`) and see the chunks immediately. Adjust parameters interactively until the output looks right. Export to JSON or JSONL for downstream processing. The CLI reads from files or stdin, so it slots into shell pipelines naturally.
 
-The **REST API** makes the chunker available as a microservice. Start it with `cognigraph-chunker serve`, and any application can send text to `/api/v1/chunk`, `/api/v1/split`, `/api/v1/semantic`, or `/api/v1/merge` and receive structured JSON responses. Bearer token authentication, CORS configuration, SSRF protection on embedding provider URLs, request size limits, and timeouts are all built in. Deploy it alongside your ingestion pipeline and call it from any language.
+The **REST API** makes the chunker available as a microservice. Start it with `cognigraph-chunker serve`, and any application can send text to the appropriate endpoint and receive structured JSON responses. Bearer token authentication, CORS configuration, SSRF protection on embedding provider URLs, request size limits, and timeouts are all built in.
 
-The **Python bindings** bring the Rust performance into Python workflows. The `Chunker` class is an iterator — loop over chunks in a `for` statement, or call `collect_chunks()` to get them all at once. The `semantic_chunk()` function runs the full pipeline with your choice of embedding provider. Signal processing primitives like `savgol_filter()` and `windowed_cross_similarity()` are exposed individually for custom pipelines, with NumPy array support for interoperability with the scientific Python ecosystem.
+| Endpoint | Strategy |
+|----------|----------|
+| `POST /api/v1/chunk` | Fixed-size |
+| `POST /api/v1/split` | Delimiter |
+| `POST /api/v1/semantic` | Semantic |
+| `POST /api/v1/cognitive` | Cognitive |
+| `POST /api/v1/intent` | Intent-driven |
+| `POST /api/v1/enriched` | Enriched |
+| `POST /api/v1/topo` | Topology-aware |
+| `POST /api/v1/adaptive` | Adaptive |
+| `POST /api/v1/merge` | Token-aware merge (post-processing) |
 
-**Docker** wraps the REST API for container-based deployment. The multi-stage Dockerfile produces a minimal image, and the server respects the `PORT` environment variable that platforms like Railway, Render, and Fly.io inject automatically. Set `API_KEY` for authentication and `OPENAI_API_KEY` if you want the OpenAI embedding provider available, and you're running.
+The **Python bindings** bring the Rust performance into Python workflows. The `Chunker` class is an iterator -- loop over chunks in a `for` statement, or call `collect_chunks()` to get them all at once. The `semantic_chunk()` function runs the full semantic pipeline with your choice of embedding provider. Signal processing primitives like `savgol_filter()` and `windowed_cross_similarity()` are exposed individually with NumPy support.
+
+**Docker** wraps the REST API for container-based deployment. The multi-stage Dockerfile produces a minimal image, and the server respects the `PORT` environment variable that platforms like Railway, Render, and Fly.io inject automatically. Set `API_KEY` for authentication and provider credentials via environment variables, and you're running.
 
 ## Five embedding providers
 
-Semantic chunking requires an embedding model, and different environments call for different providers. CogniGraph Chunker supports five out of the box.
+Strategies that use embeddings (semantic, cognitive, intent, adaptive) require an embedding model. CogniGraph Chunker supports five providers through a unified trait -- switching between them is a one-parameter change.
 
 **Ollama** is the default. If you're running Ollama locally with a model like `nomic-embed-text`, semantic chunking works with zero configuration. No API keys, no network calls to external services, no cost per request. This is the right choice for development, experimentation, and environments where data can't leave the machine.
 
-**OpenAI** provides access to models like `text-embedding-3-small` via the OpenAI API. The provider handles authentication (API key via flag, environment variable, or `.env.openai` file), batched requests, and error parsing. Use this when you want high-quality embeddings and are comfortable with the API cost and latency.
+**OpenAI** provides access to models like `text-embedding-3-small` via the OpenAI API. The provider handles authentication (API key via flag, environment variable, or `.env.openai` file), batched requests, and error parsing.
 
-**ONNX Runtime** runs sentence-transformer models locally with no Python dependency and no network calls. Point it at a directory containing `model.onnx` and `tokenizer.json` (compatible with HuggingFace ONNX exports like `all-MiniLM-L6-v2`), and it handles tokenization, padding, inference, and mean pooling internally. This gives you local inference with the flexibility to choose your own model.
+**ONNX Runtime** runs sentence-transformer models locally with no Python dependency and no network calls. Point it at a directory containing `model.onnx` and `tokenizer.json`, and it handles tokenization, padding, inference, and mean pooling internally.
 
-**Cloudflare Workers AI** uses Cloudflare's hosted embedding models like `@cf/baai/bge-m3` and `@cf/qwen/qwen3-embedding-0.6b`. Authentication is handled via a Cloudflare API token, which is verified at startup before any embedding requests are made. Credentials can be provided through CLI flags, environment variables, or a `.env.cloudflare` file. For teams already using Cloudflare's infrastructure, the provider also supports routing requests through an AI Gateway for centralized logging, rate limiting, and analytics — just set the gateway name and both the gateway authentication and provider authentication are handled automatically.
+**Cloudflare Workers AI** uses Cloudflare's hosted embedding models. Authentication via Cloudflare API token, with optional AI Gateway routing for centralized logging and rate limiting.
 
-**OAuth** covers OpenAI-compatible APIs that sit behind OAuth2 client credentials authentication — a common pattern in enterprise environments where a corporate API gateway mediates access to LLM services. The provider acquires a bearer token automatically, caches it, and refreshes it before expiry. Credentials come from CLI flags, environment variables, or a `.env.oauth` file. For endpoints behind corporate proxies with custom certificate authorities, TLS verification can be disabled with a flag. This means teams running behind an API gateway like Azure API Management or similar can use the same semantic chunking pipeline without any custom integration work.
+**OAuth** covers OpenAI-compatible APIs behind OAuth2 client credentials authentication -- a common pattern in enterprise environments where a corporate API gateway mediates access to LLM services.
 
-All five providers implement the same trait, so switching between them is a one-parameter change. The chunking pipeline doesn't know or care which provider is running — it just receives embedding vectors and processes them the same way.
+Strategies that need only an LLM (enriched, topo) and not embeddings use an OpenAI-compatible completion API directly. The default model is `gpt-4.1-mini`.
 
 ## Performance
 
 The core algorithms are written in Rust and operate on byte slices for zero-copy performance. Delimiter search uses SIMD-accelerated `memchr` for one to three delimiters and a lookup table for four or more. Multi-pattern splitting compiles an Aho-Corasick automaton once and reuses it across calls. The Savitzky-Golay filter computes coefficients via matrix operations and applies them through convolution.
 
-For non-semantic strategies, chunking a multi-megabyte document takes microseconds. The semantic pipeline is dominated by embedding computation — the signal processing and boundary detection add negligible overhead on top of the provider latency. With a local ONNX model, end-to-end semantic chunking of a 100-page document completes in seconds.
+For non-semantic strategies, chunking a multi-megabyte document takes microseconds. For embedding-based strategies, embedding computation dominates -- the signal processing and boundary detection add negligible overhead. For LLM-based strategies (intent, enriched, topo), the LLM calls dominate. Adaptive chunking is the most expensive because it runs multiple candidates, but pre-screening keeps the cost practical.
 
 The project includes Criterion benchmarks covering chunking, splitting, merging, signal processing, markdown parsing, and sentence segmentation, so performance regressions are caught before they ship.
 
@@ -48,13 +125,13 @@ The project includes Criterion benchmarks covering chunking, splitting, merging,
 
 There are other chunking libraries. What sets CogniGraph Chunker apart is the combination of features in a single, cohesive toolkit.
 
-Markdown-aware semantic chunking is the headline feature. Most chunkers treat markdown as plain text or offer only fixed-size splitting. CogniGraph Chunker parses the AST, keeps structural elements atomic, sentence-splits paragraphs, embeds everything, and finds topic boundaries using signal processing — all in one pipeline call.
+Eight strategies spanning the full complexity spectrum -- from microsecond byte splitting to LLM-powered adaptive selection -- means you can start simple and move up without changing your infrastructure.
 
-The multi-interface design means you're not locked into one integration pattern. Prototype in the CLI, deploy as a microservice, call from Python, or run in a container — same algorithms, same parameters, same results.
+Markdown-aware semantic and cognitive chunking parses the AST, keeps structural elements atomic, sentence-splits paragraphs, embeds everything, and finds topic boundaries using signal processing -- all in one pipeline call.
 
-The embedding provider abstraction means you can start with a free local model and move to a cloud API without changing your chunking code. Or run ONNX in production for zero-dependency local inference.
+The multi-interface design means you're not locked into one integration pattern. Prototype in the CLI, deploy as a microservice, call from Python, or run in a container -- same algorithms, same parameters, same results.
 
-And it's written in Rust, so it's fast, memory-safe, and compiles to a single binary with no runtime dependencies (beyond ONNX Runtime if you use the ONNX provider).
+The embedding provider abstraction means you can start with a free local model and move to a cloud API without changing your chunking code. And it's written in Rust, so it's fast, memory-safe, and compiles to a single binary with no runtime dependencies.
 
 ## Getting started
 
@@ -89,6 +166,21 @@ cognigraph-chunker split -i document.md -d ".?!" --merge --chunk-size 256
 
 # Semantic chunking (requires Ollama or another provider)
 cognigraph-chunker semantic -i document.md -f json
+
+# Cognitive chunking with entity preservation
+cognigraph-chunker cognitive -i document.md --provider ollama -f json
+
+# Intent-driven chunking optimized for retrieval
+cognigraph-chunker intent -i document.md -p openai --api-key $KEY
+
+# Enriched chunking with self-describing metadata
+cognigraph-chunker enriched -i document.md --api-key $KEY -f json
+
+# Topology-aware chunking for nested documents
+cognigraph-chunker topo -i document.md --api-key $KEY
+
+# Adaptive: let the toolkit pick the best method
+cognigraph-chunker adaptive -i document.md -p openai --api-key $KEY
 ```
 
 The project is open source under the MIT license. The source, documentation, and issue tracker are on GitHub at [gedankrayze/cognigraph-chunker](https://github.com/gedankrayze/cognigraph-chunker).

--- a/docs/08-the-complete-chunking-toolkit.md
+++ b/docs/08-the-complete-chunking-toolkit.md
@@ -1,14 +1,30 @@
 # The Complete Chunking Toolkit: From Bytes to Meaning
 
-The previous seven articles walked through a progression. We started with why chunking matters for AI retrieval, moved through fixed-size and delimiter strategies, introduced semantic chunking with embeddings and signal processing, showed how markdown-aware parsing preserves document structure, explained how token-aware merging normalizes chunk sizes, brought it all together in a single toolkit, and finally introduced cognition-aware chunking that preserves meaning across boundaries. This article is the complete picture — every chunking strategy CogniGraph Chunker offers, when to use each one, and how they compose into a pipeline that handles anything from a 500-word blog post to a 200-page clinical trial protocol.
+The previous articles walked through a progression. We started with why chunking matters for AI retrieval, moved through fixed-size and delimiter strategies, introduced semantic chunking with embeddings and signal processing, showed how markdown-aware parsing preserves document structure, explained how token-aware merging normalizes chunk sizes, brought it all together in a single toolkit, and introduced cognition-aware chunking that preserves meaning across boundaries. Since then, the toolkit has grown to include intent-driven chunking, topology-aware chunking, enriched chunking, and adaptive method selection. This article is the complete picture -- every chunking strategy CogniGraph Chunker offers, when to use each one, and how they compose into a pipeline that handles anything from a 500-word blog post to a 200-page clinical trial protocol.
 
-## Five strategies, one toolkit
+## Eight strategies, one toolkit
 
-CogniGraph Chunker implements five chunking strategies. They form a hierarchy: each level builds on the one below it, adding capability at the cost of complexity.
+CogniGraph Chunker implements eight chunking strategies. They form a progression along two axes: structural awareness and intelligence source. The first four strategies use heuristics and embeddings. The last four add LLM reasoning.
+
+```
+Heuristic / Embedding methods:
+  Fixed-size        -> byte-level splitting with boundary awareness
+    + Delimiter     -> sentence-level splitting with pattern matching
+      + Semantic    -> embedding-based topic boundary detection
+        + Cognitive -> multi-signal boundary scoring with enrichment
+
+LLM-augmented methods:
+  Intent-driven     -> query-aligned boundaries via DP optimization
+  Enriched          -> self-describing chunks with metadata extraction
+  Topology-aware    -> SIR tree + dual-agent section classification
+  Adaptive          -> meta-router: runs candidates, picks best by quality score
+```
+
+Token-aware merging can be applied as a post-processing step after any strategy, grouping small chunks into right-sized units for your embedding model. Markdown-aware parsing runs automatically in the semantic, cognitive, intent, enriched, and topology-aware pipelines.
 
 ### 1. Fixed-size chunking
 
-The simplest strategy. Set a target size in bytes or characters, and the chunker walks through the text producing chunks of that size. Boundary awareness softens the edges — instead of cutting mid-word, the chunker looks for the nearest whitespace or punctuation to break cleanly.
+The simplest strategy. Set a target size in bytes or characters, and the chunker walks through the text producing chunks of that size. Boundary awareness softens the edges -- instead of cutting mid-word, the chunker looks for the nearest whitespace or punctuation to break cleanly.
 
 This is the right choice when uniformity matters more than coherence. Embedding models with strict token limits, batch processing pipelines that need predictable chunk sizes, or situations where the text has no meaningful structure to preserve.
 
@@ -21,7 +37,7 @@ cognigraph-chunker chunk -i document.md -s 1024
 
 ### 2. Delimiter splitting
 
-Split at every occurrence of a delimiter — sentence-ending punctuation, newlines, custom patterns. Multi-pattern matching uses an Aho-Corasick automaton compiled once and reused, so even complex delimiter sets add no per-character overhead.
+Split at every occurrence of a delimiter -- sentence-ending punctuation, newlines, custom patterns. Multi-pattern matching uses an Aho-Corasick automaton compiled once and reused, so even complex delimiter sets add no per-character overhead.
 
 This produces natural units (sentences, paragraphs) rather than arbitrary byte ranges. Combine it with token-aware merging to group short sentences into right-sized chunks.
 
@@ -36,7 +52,7 @@ cognigraph-chunker split -i document.md -d ".?!" --merge --chunk-size 256
 
 The first strategy that understands content. Each block gets an embedding vector from an embedding model, and the pipeline computes cosine similarity between adjacent blocks. A Savitzky-Golay filter smooths the similarity curve, and local minima (valleys) become candidate split points. Where similarity drops, topics change, and the chunker splits.
 
-This requires an embedding provider — Ollama, OpenAI, ONNX Runtime, Cloudflare Workers AI, or an OAuth-protected endpoint — but the result is chunks that align with actual topic boundaries rather than arbitrary positions.
+This requires an embedding provider -- Ollama, OpenAI, ONNX Runtime, Cloudflare Workers AI, or an OAuth-protected endpoint -- but the result is chunks that align with actual topic boundaries rather than arbitrary positions.
 
 ```sh
 cognigraph-chunker semantic -i document.md --provider ollama
@@ -49,48 +65,83 @@ cognigraph-chunker semantic -i document.md --provider ollama
 
 Extends semantic chunking with eight signals instead of one. Beyond embedding similarity, the boundary scorer evaluates entity continuity, discourse continuation, heading context, structural affinity, topic shift, orphan risk, and budget pressure. Blocks are enriched with named entities, pronouns, demonstratives, discourse markers, and heading ancestry before scoring.
 
-The result is chunks that preserve not just topics but propositions — the "who did what to whom" structure that makes text retrievable and answerable.
+The result is chunks that preserve not just topics but propositions -- the "who did what to whom" structure that makes text retrievable and answerable.
 
 ```sh
 cognigraph-chunker cognitive -i document.md --provider ollama
 ```
 
-**Strengths:** Preserves entity chains, causal links, and discourse structure. Heading attachment. Cross-chunk entity tracking. Quality metrics on every run. Multilingual support for 14 language groups.
+**Strengths:** Preserves entity chains, causal links, and discourse structure. Heading attachment. Cross-chunk entity tracking. Quality metrics on every run. Multilingual support for 14 language groups. Optional cross-encoder reranking on ambiguous boundaries.
 **Weaknesses:** More computation than semantic chunking (though embedding latency still dominates). Not needed for simple, topically distinct documents.
 
-### 5. Cognitive chunking with reranking
+### 5. Intent-driven chunking
 
-For documents where boundary decisions are close calls, ambiguous boundaries (those within half a standard deviation of the mean join score) can be refined by a cross-encoder model. The reranker scores the text pair through a sequence classification model, and the result is blended with the original similarity score.
+Optimizes boundaries for predicted user queries rather than topic transitions. An LLM generates 10-30 hypothetical queries that users might ask about the document, classified by type (factual, procedural, conceptual, comparative). Each candidate chunk is scored by the cosine similarity between its centroid embedding and the intent embeddings. Dynamic programming finds the globally optimal partition -- unlike greedy approaches, the DP evaluates downstream consequences of every boundary decision.
 
-Typically 10-20% of boundaries qualify as ambiguous, so the reranker processes a fraction of the total — enough to improve precision without O(n) inference cost.
+This is the right choice when retrieval quality is the primary objective and you can tolerate the cost of an LLM call plus embedding the generated intents. It works best for reference manuals, knowledge bases, FAQ compilations, and compliance documents where users have diverse, specific information needs. See [Article 10](10-intent-driven-chunking.md) for the full pipeline description.
 
 ```sh
-cognigraph-chunker cognitive -i document.md --reranker models/ms-marco-MiniLM-L-6-v2
+cognigraph-chunker intent -i document.md -p openai --api-key $OPENAI_API_KEY
 ```
 
-**Strengths:** Precision improvement on uncertain boundaries. Selective — only processes ambiguous cases.
-**Weaknesses:** Requires an ONNX reranker model. Additional latency on ambiguous boundaries.
+**Strengths:** Chunks align with how readers search, not how authors organize. DP optimization avoids greedy traps. Partition score provides a direct quality measure.
+**Weaknesses:** Requires both an LLM and an embedding provider -- the most expensive method per document. Less useful for short documents or documents where structure itself is the information.
+**Requires:** Embedding provider + LLM.
 
-## How the strategies compose
+### 6. Enriched chunking
 
-These strategies aren't mutually exclusive alternatives — they're layers that compose. The cognitive pipeline includes everything below it:
+Produces self-describing chunks. Each chunk carries seven metadata fields extracted in a single LLM call: title, summary, keywords, typed entities, hypothetical questions, semantic keys, and category. Initial grouping is purely structural (no embeddings needed). The semantic keys create a rolling concept dictionary -- when the LLM processes chunks sequentially, it reuses keys for recurring concepts, creating explicit links between chunks. A recombination step merges chunks sharing the same keys using bin-packing.
 
-```
-Fixed-size         → byte-level splitting with boundary awareness
-  + Delimiter      → sentence-level splitting with pattern matching
-    + Markdown     → AST-aware block extraction (headings, tables, code, lists)
-      + Semantic   → embedding-based topic boundary detection
-        + Cognitive → multi-signal boundary scoring with enrichment
-          + Reranker → cross-encoder refinement on ambiguous boundaries
+This is the right choice when your retrieval pipeline supports hybrid search (BM25 + dense vectors), when you need HyDE-style retrieval, or when chunks need to be self-describing for downstream consumers that cannot access the original document. See [Article 12](12-enriched-chunking.md) for the full pipeline description.
+
+```sh
+cognigraph-chunker enriched -i document.md --api-key $OPENAI_API_KEY
 ```
 
-Token-aware merging can be applied as a post-processing step after any strategy, grouping small chunks into right-sized units for your embedding model.
+**Strengths:** Rich metadata enables hybrid retrieval (BM25 over keywords, HyDE via hypothetical questions, entity-type filtering, category routing). Semantic key dictionary provides concept-level document index. No embedding provider needed.
+**Weaknesses:** LLM cost scales linearly with chunk count. Metadata fields go unused if retrieval is purely dense-vector-based.
+**Requires:** LLM only (no embeddings).
 
-Markdown-aware parsing runs automatically in the semantic and cognitive pipelines. You don't need to configure it — the parser detects and preserves headings, tables, code blocks, lists, and block quotes as atomic units.
+### 7. Topology-aware chunking
+
+Builds a Structured Intermediate Representation (SIR) -- a tree mirroring the document's heading hierarchy with content blocks as leaves and cross-reference edges linking blocks that share entities or discourse continuations. Two LLM agents then make boundary decisions. The Inspector classifies each section node as atomic (keep together), splittable (can divide at block boundaries), or merge candidate (too small to stand alone). The Refiner determines optimal split points for splittable sections, merge directions for small sections, and handles cross-section dependencies.
+
+This is the right choice for deeply nested documents where heading hierarchy carries structural meaning: research papers, technical specifications, API documentation, legal documents with articles and sub-articles. See [Article 11](11-topology-aware-chunking.md) for the full pipeline description.
+
+```sh
+cognigraph-chunker topo -i document.md --api-key $OPENAI_API_KEY
+```
+
+**Strengths:** Preserves heading hierarchy and structural coupling. Cross-reference annotations between dependent sections. SIR construction is purely heuristic (no LLM calls). No embedding provider needed.
+**Weaknesses:** Less useful for flat documents without heading structure. LLM calls for two agents add latency.
+**Requires:** LLM only (no embeddings).
+
+### 8. Adaptive chunking
+
+A meta-router. It runs multiple candidate methods on the same document, scores each method's output using five intrinsic quality metrics, and returns the output from the method that scores highest. Pre-screening heuristics skip methods unlikely to help for a given document (topology-aware is skipped for flat documents, intent-driven for short documents, enriched for simple unstructured text).
+
+The five quality metrics, each scored 0.0 to 1.0:
+
+- **Size Compliance** -- fraction of chunks within the target size range
+- **Intrachunk Cohesion** -- mean sentence-to-chunk cosine similarity (is each chunk about one thing?)
+- **Contextual Coherence** -- cosine similarity between adjacent chunks (smooth transitions?)
+- **Block Integrity** -- fraction of structural elements (tables, code, lists) preserved intact
+- **Reference Completeness** -- absence of orphaned pronouns and dangling entity references at boundaries
+
+The full quality report is available with the `--report` flag, providing side-by-side comparison of how each candidate performed. See [Article 13](13-adaptive-chunking.md) for the full pipeline description.
+
+```sh
+cognigraph-chunker adaptive -i document.md -p openai --api-key $OPENAI_API_KEY \
+  --candidates semantic,cognitive,intent
+```
+
+**Strengths:** Per-document method selection without manual tuning. Quality report useful for benchmarking. Pre-screening keeps cost practical.
+**Weaknesses:** Most expensive option (runs multiple methods). Not useful when you already know which method works best.
+**Requires:** Embedding provider + optionally LLM (depending on candidates).
 
 ## Choosing a strategy
 
-The decision depends on your documents, your latency budget, and how much retrieval quality matters.
+The decision depends on your documents, your latency budget, your cost tolerance, and how much retrieval quality matters.
 
 | Scenario | Recommended strategy |
 |----------|---------------------|
@@ -99,14 +150,20 @@ The decision depends on your documents, your latency budget, and how much retrie
 | General documents with clear topic structure | Semantic |
 | Documents with entity chains, cross-references, causal reasoning | Cognitive |
 | Mission-critical retrieval where boundary precision matters | Cognitive + reranker |
+| Retrieval-optimized chunks aligned with user queries | Intent-driven |
+| Hybrid search pipelines needing rich metadata per chunk | Enriched |
+| Deeply nested documents with heading hierarchy | Topology-aware |
+| Diverse document types where no single method fits all | Adaptive |
 
-A practical approach is to start with semantic chunking. If retrieval quality is good enough, stay there. If you notice that retrieved chunks start with "It also..." or reference entities defined elsewhere, upgrade to cognitive chunking. The switch is a one-parameter change — the infrastructure, output format, and downstream pipeline stay the same.
+A practical approach is to start with semantic chunking. If retrieval quality is good enough, stay there. If retrieved chunks lack context -- they start with "It" or reference entities defined elsewhere -- upgrade to cognitive chunking. If your documents are deeply nested specifications, try topology-aware. If your retrieval pipeline supports hybrid search, enriched chunking provides the metadata to exploit it. If you process diverse document types and cannot predict the best method, use adaptive.
+
+At each step, the output format stays the same, the interfaces stay the same, and the downstream pipeline doesn't change. The chunking strategy is a parameter, not an architecture decision.
 
 ## Four interfaces, every strategy
 
-All strategies are available through all four interfaces:
+All eight strategies are available through all four interfaces:
 
-**CLI** — experiment and iterate. Pipe documents through subcommands (`chunk`, `split`, `semantic`, `cognitive`), adjust parameters with flags, and export to plain text, JSON, or JSONL.
+**CLI** -- experiment and iterate. Pipe documents through subcommands (`chunk`, `split`, `semantic`, `cognitive`, `intent`, `enriched`, `topo`, `adaptive`), adjust parameters with flags, and export to plain text, JSON, or JSONL.
 
 ```sh
 # Fixed-size
@@ -121,11 +178,20 @@ cognigraph-chunker semantic -i doc.md --provider openai -f json
 # Cognitive with relations and graph export
 cognigraph-chunker cognitive -i doc.md --provider openai --relations --graph -f json
 
-# Cognitive with reranker and signal diagnostics
-cognigraph-chunker cognitive -i doc.md --reranker models/ms-marco-MiniLM-L-6-v2 --emit-signals
+# Intent-driven with custom intent count
+cognigraph-chunker intent -i doc.md -p openai --api-key $KEY --max-intents 30
+
+# Enriched with metadata extraction
+cognigraph-chunker enriched -i doc.md --api-key $KEY -f json
+
+# Topology-aware with SIR output
+cognigraph-chunker topo -i doc.md --api-key $KEY -f json --emit-sir
+
+# Adaptive with quality report
+cognigraph-chunker adaptive -i doc.md -p openai --api-key $KEY -f json --report
 ```
 
-**REST API** — deploy as a microservice. Start with `cognigraph-chunker serve` and call endpoints:
+**REST API** -- deploy as a microservice. Start with `cognigraph-chunker serve` and call endpoints:
 
 | Endpoint | Strategy |
 |----------|----------|
@@ -133,17 +199,21 @@ cognigraph-chunker cognitive -i doc.md --reranker models/ms-marco-MiniLM-L-6-v2 
 | `POST /api/v1/split` | Delimiter |
 | `POST /api/v1/semantic` | Semantic |
 | `POST /api/v1/cognitive` | Cognitive |
+| `POST /api/v1/intent` | Intent-driven |
+| `POST /api/v1/enriched` | Enriched |
+| `POST /api/v1/topo` | Topology-aware |
+| `POST /api/v1/adaptive` | Adaptive |
 | `POST /api/v1/merge` | Token-aware merge (post-processing) |
 
 Bearer token authentication, CORS, SSRF protection, request size limits, and timeouts are built in.
 
-**Python bindings** — Rust performance in Python workflows. The `Chunker` class handles fixed-size and delimiter splitting. The `semantic_chunk()` function runs the full semantic pipeline. Signal processing primitives (`savgol_filter()`, `windowed_cross_similarity()`) are exposed individually with NumPy support.
+**Python bindings** -- Rust performance in Python workflows. The `Chunker` class handles fixed-size and delimiter splitting. The `semantic_chunk()` function runs the full semantic pipeline. Signal processing primitives (`savgol_filter()`, `windowed_cross_similarity()`) are exposed individually with NumPy support.
 
-**Docker** — container deployment with a single image. The multi-stage Dockerfile produces a minimal binary. Set `PORT`, `API_KEY`, and provider credentials via environment variables.
+**Docker** -- container deployment with a single image. The multi-stage Dockerfile produces a minimal binary. Set `PORT`, `API_KEY`, and provider credentials via environment variables.
 
 ## Five embedding providers
 
-The semantic and cognitive strategies require embeddings. CogniGraph Chunker supports five providers through a unified trait — switching between them is a one-parameter change.
+The semantic, cognitive, intent, and adaptive strategies require embeddings. CogniGraph Chunker supports five providers through a unified trait -- switching between them is a one-parameter change.
 
 | Provider | Use case | Configuration |
 |----------|----------|---------------|
@@ -153,23 +223,19 @@ The semantic and cognitive strategies require embeddings. CogniGraph Chunker sup
 | **Cloudflare Workers AI** | Teams on Cloudflare infrastructure | Auth token + account ID, optional AI Gateway |
 | **OAuth** | Enterprise API gateways (Azure, corporate proxies) | Client credentials, token URL, optional TLS override |
 
-## What cognitive chunking adds
+Strategies that need only an LLM (enriched, topo) use an OpenAI-compatible completion API directly. The default model is `gpt-4.1-mini`, configurable via `COGNIGRAPH_LLM_MODEL` or per-call flags.
 
-The cognitive pipeline is the most capable strategy in the toolkit. Beyond topic-aware boundaries, it provides:
+## LLM enrichment features
 
-**Enriched metadata per chunk** — heading ancestry, dominant entities (top 5 by frequency), all entities (full list), token estimate, and continuity confidence score.
+Several features use LLM calls to add structured information to chunks. These are available across multiple strategies:
 
-**Cross-chunk entity tracking** — a `shared_entities` map showing which entities appear in which chunks. Only entities in 2+ chunks are included, creating a focused index of concept threads that span the document.
+**Relation extraction** (`--relations` flag on cognitive chunking) -- LLM-based subject-predicate-object triple extraction per chunk. Produces structured knowledge that supports graph-based retrieval.
 
-**Proposition healing** — after initial assembly, a healing pass scans boundaries for incomplete propositions: unresolved pronouns, dangling demonstratives, discourse continuations, and high entity overlap with similar topics. Chunks that would be more coherent together are merged, as long as the combined size stays within budget.
+**Chunk synopsis** (`--synopsis` flag on cognitive chunking) -- LLM-generated one-sentence summaries per chunk for preview and navigation.
 
-**Evaluation metrics** on every run — entity orphan rate, pronoun boundary rate, heading attachment rate, and discourse break rate. These provide quantitative chunk quality assessment without human evaluation.
+**Graph export** (`--graph` flag on cognitive chunking) -- output as nodes (chunks) and edges (adjacency + shared entity links), ready for import into graph databases or visualization tools.
 
-**Relation extraction** (optional) — LLM-based subject-predicate-object triple extraction per chunk, producing structured knowledge that supports graph-based retrieval.
-
-**Graph export** (optional) — output as nodes (chunks) and edges (adjacency + shared entity links), ready for import into graph databases or visualization tools.
-
-**Multilingual support** — automatic language detection across 70+ languages, with language-specific enrichment for 14 language groups including English, German, French, Spanish, Portuguese, Italian, Dutch, Russian, Turkish, Polish, Chinese, Japanese, Korean, and Arabic. CJK text gets script-based entity detection (Katakana spans, Latin-in-CJK terms) alongside the standard heuristics.
+**Enriched metadata** (enriched chunking mode) -- title, summary, keywords, typed entities, hypothetical questions, semantic keys, and category per chunk. Enables hybrid retrieval strategies beyond dense vector similarity.
 
 ## Performance characteristics
 
@@ -182,14 +248,18 @@ The core algorithms are Rust, operating on byte slices for zero-copy performance
 | Semantic | Seconds | Embedding provider API |
 | Cognitive | Seconds | Embedding provider API (enrichment adds negligible overhead) |
 | Cognitive + reranker | Seconds | Embedding + reranker inference on ambiguous boundaries |
+| Intent-driven | Seconds | LLM (intent generation) + embedding provider |
+| Enriched | Seconds | LLM (one call per chunk for metadata extraction) |
+| Topology-aware | Seconds | LLM (two agent calls: Inspector + Refiner) |
+| Adaptive | Sum of candidates | Runs multiple methods; pre-screening reduces cost |
 
-For semantic and cognitive chunking, embedding computation dominates. The signal processing, enrichment, scoring, assembly, and healing stages together take milliseconds even on large documents. With a local ONNX embedding model, end-to-end processing of a 100-page document completes in seconds. With a remote API like OpenAI, network latency is the limiting factor.
+For embedding-based strategies, embedding computation dominates. The signal processing, enrichment, scoring, assembly, and healing stages together take milliseconds even on large documents. For LLM-based strategies, the LLM calls dominate. With a local ONNX embedding model, end-to-end processing of a 100-page document completes in seconds. With a remote API, network latency is the limiting factor.
 
 ## From simple to sophisticated
 
-The value of having all strategies in one toolkit is that you can move along the complexity axis without changing your infrastructure.
+The value of having all eight strategies in one toolkit is that you can move along the complexity axis without changing your infrastructure.
 
-Start with fixed-size chunking to get something working. Move to delimiter splitting when you need sentence-level boundaries. Add semantic chunking when you need topic awareness. Upgrade to cognitive chunking when retrieved chunks lack context — when they start with "It" or reference entities defined elsewhere. Add the reranker when boundary precision on ambiguous cases matters.
+Start with fixed-size chunking to get something working. Move to delimiter splitting when you need sentence-level boundaries. Add semantic chunking when you need topic awareness. Upgrade to cognitive chunking when retrieved chunks lack context. Switch to intent-driven when you want chunks optimized for how users actually search. Use enriched chunking when your pipeline can exploit rich metadata. Try topology-aware for deeply nested documents. Deploy adaptive when you process diverse documents and want automatic method selection.
 
 At each step, the output format stays the same, the interfaces stay the same, and the downstream pipeline doesn't change. The chunking strategy is a parameter, not an architecture decision.
 

--- a/docs/10-intent-driven-chunking.md
+++ b/docs/10-intent-driven-chunking.md
@@ -1,0 +1,83 @@
+# Intent-Driven Chunking: Optimizing for Retrieval
+
+Most chunking methods ask where to split based on properties of the text itself: topic boundaries, structural markers, entity chains. The resulting chunks reflect the author's organization of the document. But the people searching the document have their own questions, and those questions rarely align perfectly with how the author structured the content.
+
+A clinical trial protocol might organize information by study phase: background, design, endpoints, analysis plan. A regulatory reviewer searching for "what are the primary efficacy endpoints?" needs a chunk that contains the endpoint definition, the measurement schedule, and the analysis method -- information that spans parts of two or three author-defined sections. A semantic chunker produces chunks that follow the author's structure. An intent-driven chunker produces chunks that follow the reader's questions.
+
+Intent-driven chunking optimizes boundaries for predicted user queries rather than topic transitions. It asks: given the likely information needs of people who will search this document, which partition maximizes the chance that each query retrieves a single, self-contained chunk?
+
+## How it works
+
+The pipeline has three stages beyond the standard block extraction: intent prediction, alignment scoring, and dynamic programming.
+
+**Intent prediction** sends the document (or a summary of it, for long documents) to an LLM with a structured output schema. The LLM generates 10-30 hypothetical queries that users might ask about this document. Each query is classified by type: factual ("What is the recommended dose?"), procedural ("How do I configure the pipeline?"), conceptual ("Why does the system use valley detection?"), or comparative ("How does cognitive chunking differ from semantic chunking?"). The diversity of query types ensures that the resulting partition serves different retrieval patterns, not just factual lookups.
+
+**Alignment scoring** measures how well a candidate chunk answers a predicted query. For each candidate chunk (a contiguous range of blocks), the pipeline computes a centroid embedding -- the mean of the block embeddings in that range -- and calculates the cosine similarity between the centroid and every intent embedding. The alignment score for that chunk is the maximum similarity to any intent. A high score means the chunk is tightly focused on at least one predicted query. A low score means the chunk is a grab bag that doesn't cleanly answer anything.
+
+**Dynamic programming** finds the globally optimal partition. Unlike greedy approaches that make local decisions at each boundary, the DP explores all valid partitions (subject to minimum and maximum chunk sizes derived from the token budgets) and selects the one that maximizes the total alignment score across all chunks, normalized by chunk count. The time complexity is O(n * max_blocks) where n is the number of blocks, making it practical for documents up to tens of thousands of blocks.
+
+The DP formulation is the key differentiator. Greedy chunking can get trapped: a locally optimal boundary at position 50 might force a poor boundary at position 80. The DP avoids this by evaluating the downstream consequences of every boundary decision.
+
+## What the output contains
+
+Each intent chunk carries its text, byte offsets, token estimate, heading path, and two fields specific to this method: the index of the best-matching intent and the alignment score. The result also includes the full list of predicted intents with their matched chunk indices, plus the overall partition score.
+
+The partition score is a single number summarizing retrieval quality. Higher is better. When comparing different parameter settings (more or fewer intents, different token budgets), the partition score provides a direct measure of which configuration produces more retrieval-friendly chunks.
+
+## Configuration
+
+**`--max-intents`** controls how many hypothetical queries the LLM generates. The default of 20 works well for most documents. Very short documents may benefit from fewer (10), and very long documents with many distinct topics may benefit from more (30). More intents increase the chance that every chunk aligns well with at least one query, but they also increase the embedding cost.
+
+**`--soft-budget`** and **`--hard-budget`** control chunk sizes. The DP uses these to derive the minimum and maximum number of blocks per chunk. The soft budget (default 512 tokens) is the target; the hard budget (default 768 tokens) is the ceiling.
+
+**`--intent-model`** selects the LLM used for intent generation. The default is `gpt-4.1-mini`, which balances quality and cost. Any OpenAI-compatible model works.
+
+## CLI usage
+
+```sh
+# Intent-driven chunking with OpenAI embeddings
+cognigraph-chunker intent -i document.md -p openai --api-key $OPENAI_API_KEY
+
+# Custom intent count and token budgets
+cognigraph-chunker intent -i doc.md -p openai --api-key $KEY \
+  --max-intents 30 --soft-budget 256 --hard-budget 512
+
+# Use a different LLM for intent generation
+cognigraph-chunker intent -i doc.md -p openai --api-key $KEY \
+  --intent-model gpt-4.1-mini
+
+# JSON output with post-merge
+cognigraph-chunker intent -i doc.md -p openai --api-key $KEY -f json --merge
+```
+
+## API usage
+
+```
+POST /api/v1/intent
+
+{
+  "text": "...",
+  "provider": "openai",
+  "model": "text-embedding-3-small",
+  "intent_model": "gpt-4.1-mini",
+  "max_intents": 20,
+  "soft_budget": 512,
+  "hard_budget": 768
+}
+```
+
+The response includes chunks with alignment scores, the predicted intents with their matched chunk indices, and the overall partition score.
+
+## When to use intent-driven chunking
+
+Use it when retrieval quality is the primary objective and you can tolerate the cost of an LLM call plus embedding the generated intents. It works best for documents where users have diverse, specific information needs -- reference manuals, knowledge bases, FAQ compilations, compliance documents.
+
+It is less useful for documents where the structure itself is the information (deeply nested specifications, legal contracts with numbered clauses) or where the document is short enough that a single chunk suffices.
+
+Intent-driven chunking requires both an LLM (for intent generation) and an embedding provider (for alignment scoring). This makes it the most expensive method per document, but the DP optimization means the actual chunking step is fast -- the cost is dominated by the LLM and embedding calls.
+
+## Intent-driven chunking in regulated industries
+
+Pharmaceutical regulatory submissions are dense documents where reviewers search with specific questions: "What is the primary endpoint?", "What were the inclusion criteria?", "How was the DSMB constituted?" These are precisely the kinds of queries the intent predictor generates. The resulting chunks align with regulatory review patterns rather than the document's organizational structure, which means a RAG system built on intent-driven chunks returns more complete answers to reviewer queries.
+
+The alignment scores provide an auditable quality signal. A chunk with a low alignment score is a warning: it doesn't cleanly answer any predicted query, which means it may need manual review or restructuring. In validated environments, this metric can be logged alongside the chunking output as part of the processing record.

--- a/docs/11-topology-aware-chunking.md
+++ b/docs/11-topology-aware-chunking.md
@@ -1,0 +1,85 @@
+# Topology-Aware Chunking: Preserving Document Structure
+
+Some documents are flat sequences of paragraphs. Others have deep hierarchical structure: nested sections, subsections, cross-references between distant parts, tables that belong to the section that introduces them. Research papers, technical specifications, regulatory filings, and API documentation all share this property. Their structure carries meaning that flat chunking methods discard.
+
+Semantic chunking treats the document as a stream of blocks and measures embedding similarity between neighbors. It has no concept of section boundaries, heading hierarchy, or cross-section dependencies. A subsection of three paragraphs under "Methods > Data Collection" might get merged with the first paragraph of "Methods > Analysis" because the embedding similarity is high -- they are both about methods. But structurally, they belong to different units, and a reader would never confuse them.
+
+Topology-aware chunking builds an explicit representation of the document's hierarchical structure before making any boundary decisions. It then uses two LLM agents to classify sections and produce a final partition that respects the document's topology.
+
+## The Structured Intermediate Representation
+
+The first step after block extraction is constructing a Structured Intermediate Representation (SIR) -- a tree that mirrors the heading hierarchy with content blocks as leaves.
+
+A document with headings like "Introduction," "Methods > Data Collection," "Methods > Analysis," and "Results" becomes a tree where "Methods" is a parent node with two children. Each leaf node corresponds to a content block (paragraph, table, code block, list). The SIR also includes cross-reference edges: if two blocks in different sections mention the same entity, an entity co-reference edge connects them. If a block starts with a discourse continuation marker ("As described above," "Building on this"), a discourse edge links it to the preceding section.
+
+This construction reuses the heading context propagation, entity detection, and discourse marker detection from the cognitive chunking pipeline. No LLM calls are needed for SIR construction -- it is purely heuristic.
+
+## Two-agent refinement
+
+The SIR provides the structure. Two LLM agents make the boundary decisions.
+
+**The Inspector Agent** receives the SIR as a JSON tree -- section titles, block types, block lengths, and cross-reference edges, but not the full text. It classifies each section node as one of three types:
+
+- **Atomic**: the section must stay together as a single chunk. Typical for short definition sections, single-paragraph introductions, or sections that are already within the token budget.
+- **Splittable**: the section is large enough to be divided at block boundaries. The Inspector identifies which blocks are potential split points.
+- **Merge candidate**: the section is too small to stand alone and should be merged with an adjacent section. A single-paragraph subsection with no heading of its own is a common case.
+
+The Inspector also identifies cross-section dependencies: pairs of sections that reference each other and should ideally end up in the same chunk or carry explicit cross-references.
+
+**The Refiner Agent** receives the Inspector's classifications plus the SIR and the full text of sections classified as splittable. For splittable sections, it determines the optimal split points within the section. For merge candidate pairs, it decides the merge direction. For cross-section dependencies, it ensures that dependent content either stays together or gets explicit cross-reference annotations.
+
+The Refiner outputs a partition: a list of chunk groups, each specifying which section IDs and block ranges it contains. The assembly stage maps these groups back to byte ranges in the original document.
+
+## Context window handling
+
+Long documents may produce a SIR that exceeds the LLM's context window. When the SIR JSON exceeds 80% of the model's context window, large content blocks are summarized to their first and last 100 characters plus token counts. Cross-reference edges are preserved even when block text is truncated. The Refiner receives full text only for sections classified as splittable, not the entire document.
+
+## What the output contains
+
+Each topology-aware chunk carries its text, byte offsets, token estimate, heading path, the Inspector's classification (atomic, splittable, or merged), and a list of cross-reference indices pointing to other chunks that share dependencies.
+
+When `--emit-sir` is enabled (JSON output only), the response includes the full SIR structure -- useful for debugging or for downstream systems that want to reason about document topology.
+
+## CLI usage
+
+```sh
+# Topology-aware chunking
+cognigraph-chunker topo -i document.md --api-key $OPENAI_API_KEY
+
+# Custom model and budgets
+cognigraph-chunker topo -i doc.md --api-key $KEY \
+  --topo-model gpt-4.1-mini --soft-budget 256 --hard-budget 512
+
+# Include SIR in JSON output
+cognigraph-chunker topo -i doc.md --api-key $KEY -f json --emit-sir
+```
+
+## API usage
+
+```
+POST /api/v1/topo
+
+{
+  "text": "...",
+  "topo_model": "gpt-4.1-mini",
+  "soft_budget": 512,
+  "hard_budget": 768,
+  "emit_sir": false
+}
+```
+
+The response includes chunks with section classifications and cross-reference indices.
+
+## When to use topology-aware chunking
+
+Use it for deeply nested documents where the heading hierarchy carries structural meaning: research papers with sections and subsections, technical specifications with numbered clauses, API documentation with grouped endpoints, legal documents with articles and sub-articles.
+
+It is less useful for flat documents (blog posts, narrative text, meeting transcripts) that lack heading structure. The pre-screening heuristic in adaptive mode skips topology-aware chunking when a document has fewer than two heading levels.
+
+Topology-aware chunking requires an LLM (for the two agent calls) but does not require an embedding provider. This makes it a good choice when you need structure-preserving chunking without the cost of embedding every block.
+
+## Topology-aware chunking for technical documentation
+
+API documentation is a natural fit. An API reference might have a top-level "Authentication" section with subsections for "API Keys," "OAuth," and "JWT." Each subsection contains a description, a code example, and a table of parameters. Semantic chunking might split the code example from its parameter table because the embedding similarity between code and a markdown table is low. Topology-aware chunking keeps them together because the Inspector classifies the subsection as atomic -- it is small enough to be one chunk, and its internal blocks are structurally coupled.
+
+For specifications with numbered requirements (ISO standards, NIST guidelines, internal compliance policies), the SIR preserves the numbering hierarchy. A requirement like "4.3.2.1 The system SHALL encrypt data at rest" stays connected to its parent requirement "4.3.2 Data Protection" and its sibling requirements. Cross-reference edges link requirements that reference each other, ensuring that a retrieval system can surface the full context for any requirement, not just the sentence that mentions it.

--- a/docs/12-enriched-chunking.md
+++ b/docs/12-enriched-chunking.md
@@ -1,0 +1,95 @@
+# Enriched Chunking: Self-Describing Chunks for RAG
+
+Standard chunking produces text fragments. A retrieval system embeds them, indexes them, and hopes that the embedding captures enough of what the chunk is about. But embeddings are lossy. A chunk about dosing protocols for a specific compound might embed close to a chunk about clinical trial phases in general -- both are "pharmaceutical" in embedding space, but they answer very different questions.
+
+Enriched chunking produces chunks that describe themselves. Each chunk carries a title, a summary, a keyword list, typed entities, hypothetical questions the chunk can answer, semantic keys for cross-chunk linking, and a category label. These metadata fields enable retrieval strategies that go beyond dense vector similarity: BM25 over keywords and titles, HyDE-style matching against hypothetical questions, entity-type filtering, and category-based routing.
+
+The key insight is that all seven metadata fields can be extracted in a single LLM call per chunk, and the semantic keys enable a recombination step that merges chunks sharing the same conceptual thread.
+
+## How the pipeline works
+
+**Initial grouping** divides the document into preliminary chunks using simple structural rules. Blocks accumulate until the soft token budget is reached. Headings start new chunks. Atomic blocks (tables, code blocks, complete lists) are never split. No embeddings are needed -- this step is purely structural.
+
+**Single-call LLM enrichment** sends each preliminary chunk to the LLM with a structured output schema requesting all seven fields at once. The prompt includes the chunk text and a rolling semantic key dictionary -- the set of keys assigned to previously processed chunks. This context lets the LLM reuse existing keys when a new chunk covers the same concept, creating explicit links between chunks.
+
+The seven metadata fields are:
+
+- **title**: a concise descriptive title for the chunk content
+- **summary**: a 1-2 sentence summary of what the chunk covers
+- **keywords**: terms that a user might search for when looking for this content
+- **typed_entities**: named entities with type labels (person, organization, compound, location, etc.)
+- **hypothetical_questions**: 2-4 questions that this chunk can answer, suitable for HyDE retrieval
+- **semantic_keys**: normalized concept identifiers (e.g., "xr-7742-dosing", "clinical-protocol") that link chunks covering the same topic
+- **category**: a single label classifying the chunk's role (background, methodology, results, discussion, etc.)
+
+**Key-based recombination** examines the semantic key dictionary after all chunks are enriched. Chunks sharing identical keys are candidates for merging. The recombination uses a bin-packing strategy: same-key chunks that are also adjacent in document order are merged first, then non-adjacent same-key chunks are merged if the combined size fits within the hard budget. Chunks with unique keys remain untouched.
+
+**Re-enrichment** runs only on chunks that were actually merged. Since the merged chunk has new content, its title and summary are updated via a lightweight LLM call. Keywords, entities, questions, and keys from the constituent chunks are preserved as a union -- no information is lost.
+
+## The rolling key dictionary
+
+The rolling key dictionary is what makes enriched chunking more than just "chunking plus metadata." As the LLM processes chunks sequentially, it sees which concepts have already been named. When chunk 5 discusses the same dosing protocol as chunk 1, the LLM reuses the key "xr-7742-dosing" rather than inventing a new one. This creates an explicit link between the two chunks without requiring embeddings or entity matching.
+
+The dictionary is a map from key names to lists of chunk indices. After processing, it provides a concept-level index of the document: "xr-7742-dosing" appears in chunks [0, 3, 7], "clinical-protocol" appears in chunks [0, 1, 3]. This is directly usable for graph-based retrieval or for augmenting a vector index with concept links.
+
+## Configuration
+
+**`--enrichment-model`** selects the LLM for enrichment calls. The default is `gpt-4.1-mini`.
+
+**`--soft-budget`** and **`--hard-budget`** control initial grouping sizes and the hard ceiling for recombined chunks.
+
+**`--no-recombine`** skips the key-based recombination step, producing chunks with metadata but no merging.
+
+**`--no-re-enrich`** skips the re-enrichment of merged chunks, keeping the original titles and summaries from the constituent chunks.
+
+## CLI usage
+
+```sh
+# Enriched chunking with metadata extraction
+cognigraph-chunker enriched -i document.md --api-key $OPENAI_API_KEY
+
+# Custom model and budgets
+cognigraph-chunker enriched -i doc.md --api-key $KEY \
+  --enrichment-model gpt-4.1-mini --soft-budget 256 --hard-budget 512
+
+# Skip recombination (metadata only, no merging)
+cognigraph-chunker enriched -i doc.md --api-key $KEY --no-recombine
+
+# JSON output
+cognigraph-chunker enriched -i doc.md --api-key $KEY -f json
+```
+
+## API usage
+
+```
+POST /api/v1/enriched
+
+{
+  "text": "...",
+  "enrichment_model": "gpt-4.1-mini",
+  "soft_budget": 512,
+  "hard_budget": 768,
+  "recombine": true,
+  "re_enrich": true
+}
+```
+
+The response includes chunks with all seven metadata fields plus the semantic key dictionary.
+
+## When to use enriched chunking
+
+Use it when your retrieval pipeline supports hybrid search (BM25 + dense vectors), when you need HyDE-style retrieval (matching queries against hypothetical questions), or when chunks need to be self-describing for downstream consumers that cannot access the original document.
+
+Enriched chunking is especially valuable for knowledge bases where chunks are stored independently of their source documents. The title, summary, and category provide enough context for a human to understand what a chunk is about without reading it. The hypothetical questions provide alternative query surfaces for retrieval. The typed entities enable faceted filtering.
+
+It is less useful when retrieval is purely dense-vector-based and metadata fields would go unused, or when LLM cost per chunk is a concern. Each chunk requires one LLM call for enrichment (and potentially a second for re-enrichment after merging), so the cost scales linearly with chunk count.
+
+Enriched chunking does not require an embedding provider. It relies on the LLM for metadata extraction and on structural heuristics for initial grouping. This makes it a good choice when you want rich metadata without the cost or complexity of running an embedding model.
+
+## Enriched chunking for enterprise search
+
+Enterprise knowledge bases accumulate documents from many sources: wikis, runbooks, policy documents, incident reports. These documents use different terminology for the same concepts. A runbook might call it "the primary database," a policy document might call it "the production data store," and an incident report might call it "prod-db-01."
+
+The semantic key dictionary normalizes these references. When the LLM enriches a runbook chunk about failover procedures, it assigns the key "production-database-failover." When it encounters an incident report chunk describing a database outage, it reuses the same key. The result is a concept-level index that bridges vocabulary differences across document sources -- something that embedding similarity alone cannot reliably achieve.
+
+The hypothetical questions field is particularly useful for enterprise search. Users searching an internal knowledge base often phrase queries as questions: "How do I reset the database password?" or "What is the escalation procedure for a P1 incident?" The hypothetical questions generated by the LLM match these natural query patterns, providing a retrieval surface that embeddings of the chunk text alone may not capture.

--- a/docs/13-adaptive-chunking.md
+++ b/docs/13-adaptive-chunking.md
@@ -1,0 +1,105 @@
+# Adaptive Chunking: Automatic Method Selection
+
+No single chunking method works best for all documents. A flat blog post with clear topic transitions is well served by semantic chunking. A deeply nested specification needs topology-aware chunking. A knowledge base article intended for RAG retrieval benefits from intent-driven or enriched chunking. Choosing the right method requires understanding both the document and the downstream use case -- knowledge that is often unavailable when building a chunking pipeline for diverse input.
+
+Adaptive chunking is a meta-router. It runs multiple candidate methods on the same document, scores each method's output using five intrinsic quality metrics, and returns the output from the method that scores highest. The result is per-document method selection without manual tuning.
+
+## The five quality metrics
+
+Each metric is scored from 0.0 to 1.0. Together they measure whether the chunks are well-sized, internally coherent, properly bounded, and free of broken references.
+
+**Size Compliance (SC)** measures whether chunks fall within the target size range. It counts the fraction of chunks whose token count is between half the soft budget and the hard budget. A score of 1.0 means every chunk is appropriately sized. Low scores indicate fragmentation (too many small chunks) or monolithic chunks (too few, too large).
+
+**Intrachunk Cohesion (ICC)** measures whether each chunk is about one thing. For each chunk, the pipeline splits it into sentences, embeds each sentence and the full chunk text, and computes the mean cosine similarity of sentence embeddings to the chunk embedding. A cohesive chunk has high internal similarity; a chunk that covers multiple unrelated topics has low similarity. ICC is the mean of per-chunk cohesion scores.
+
+**Contextual Coherence (DCC)** measures the smoothness of transitions between adjacent chunks. For each pair of consecutive chunks, it computes the cosine similarity of their embeddings. Higher values indicate smoother transitions. Very high values may indicate under-splitting (the chunks are so similar they should have been one chunk), but in practice this metric rewards methods that avoid jarring topic jumps at chunk boundaries.
+
+**Block Integrity (BI)** measures whether structural elements are preserved intact. It counts the fraction of tables, code blocks, lists, and block quotes that are fully contained within a single chunk rather than split across boundaries. A score of 1.0 means no structural element is broken.
+
+**Reference Completeness (RC)** measures whether chunks start with unresolved references. For each chunk boundary, it checks whether the next chunk begins with a pronoun or demonstrative that has no antecedent in the same chunk, and whether entities introduced in the previous chunk are orphaned. RC maps directly to the orphan risk and entity continuity signals from cognitive chunking.
+
+The five metrics are combined into a composite score with configurable weights. The default is equal weighting (0.20 each). Custom weights let you prioritize what matters for your use case: a RAG pipeline might weight ICC and RC higher; a structural preservation pipeline might weight BI higher.
+
+## Pre-screening
+
+Running every candidate method on every document would be wasteful. Pre-screening applies lightweight heuristics to skip methods that are unlikely to help:
+
+- **Topology-aware** is skipped if the document has fewer than two heading levels. A flat document has no topology to preserve.
+- **Intent-driven** is skipped if the document is under 500 tokens. Too short for meaningful intent generation.
+- **Enriched** is skipped if the document has no markdown structure and is under 1000 tokens. Too simple to benefit from the enrichment overhead.
+- **Cognitive** and **semantic** are always included as general-purpose methods.
+
+Pre-screening is advisory. The `--force-candidates` flag overrides it.
+
+## How winner selection works
+
+After all candidate methods have run, each method's output is scored on all five metrics. The composite scores are compared, and the method with the highest score wins. Ties are broken by preferring fewer chunks (less fragmentation).
+
+The full quality report is available in the output (JSON format, `--report` flag). This includes each candidate's per-metric scores, composite score, chunk count, and total tokens. The report is valuable for understanding why the adaptive router chose a particular method and for identifying documents where multiple methods perform similarly.
+
+## Configuration
+
+**`--candidates`** restricts which methods are evaluated. Default: `semantic,cognitive,intent,enriched,topo`. Restricting candidates reduces cost but may miss the best method.
+
+**`--force-candidates`** bypasses pre-screening heuristics, running all specified candidates regardless of document characteristics.
+
+**`--metric-weights`** sets custom weights for the composite score. Format: `sc=0.15,icc=0.25,dcc=0.20,bi=0.20,rc=0.20`. Weights must sum to 1.0.
+
+**`--soft-budget`** and **`--hard-budget`** are passed through to all candidate methods.
+
+## CLI usage
+
+```sh
+# Adaptive chunking with all candidates
+cognigraph-chunker adaptive -i document.md -p openai --api-key $OPENAI_API_KEY
+
+# Restrict candidates
+cognigraph-chunker adaptive -i doc.md -p openai --api-key $KEY \
+  --candidates semantic,cognitive,intent
+
+# Custom metric weights (prioritize cohesion and reference completeness)
+cognigraph-chunker adaptive -i doc.md -p openai --api-key $KEY \
+  --metric-weights sc=0.10,icc=0.30,dcc=0.15,bi=0.15,rc=0.30
+
+# Include full quality report in output
+cognigraph-chunker adaptive -i doc.md -p openai --api-key $KEY -f json --report
+
+# Force all candidates (skip pre-screening)
+cognigraph-chunker adaptive -i doc.md -p openai --api-key $KEY --force-candidates
+```
+
+## API usage
+
+```
+POST /api/v1/adaptive
+
+{
+  "text": "...",
+  "provider": "openai",
+  "model": "text-embedding-3-small",
+  "api_key": "...",
+  "candidates": ["semantic", "cognitive", "intent", "enriched"],
+  "soft_budget": 512,
+  "hard_budget": 768,
+  "metric_weights": { "sc": 0.20, "icc": 0.20, "dcc": 0.20, "bi": 0.20, "rc": 0.20 },
+  "include_report": true
+}
+```
+
+The response includes the winner's name, its chunks, and optionally the full quality report with per-candidate metrics.
+
+## When to use adaptive chunking
+
+Use it when you process documents from diverse sources and cannot predict which chunking method will work best for each one. A pipeline ingesting research papers, blog posts, API documentation, and compliance manuals benefits from adaptive routing because each document type has different structural properties.
+
+Use it for benchmarking. The quality report provides a side-by-side comparison of how different methods perform on the same document. This is valuable when evaluating chunking strategies for a new domain or when fine-tuning method parameters.
+
+It is less useful when you already know which method works best for your documents (use that method directly) or when cost is the primary constraint (adaptive runs multiple methods, multiplying the compute cost).
+
+Adaptive chunking requires an embedding provider (for ICC and DCC metrics) and may require an LLM (depending on which candidates are included). The cost is the sum of running all non-screened candidates plus the metric computation.
+
+## The quality metrics as a standalone module
+
+The five quality metrics are implemented as a standalone module that can evaluate any chunking output, not just adaptive candidates. The evaluation API endpoint (`POST /api/v1/evaluate`) accepts pre-chunked text and returns metric scores. This enables continuous quality monitoring: run your chunking pipeline, feed the output to the evaluator, and track quality over time.
+
+The metrics are also available as assertions in tests. A CI pipeline can chunk a reference document, compute metrics, and assert that size compliance stays above 0.85 or reference completeness stays above 0.90. This catches regressions in chunking quality as the codebase evolves.

--- a/docs/superpowers/plans/2026-04-10-new-chunking-methods.md
+++ b/docs/superpowers/plans/2026-04-10-new-chunking-methods.md
@@ -1,0 +1,2027 @@
+# New Chunking Methods Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 4 new chunking methods (intent, topo, enriched, adaptive) + a standalone quality metrics module as first-class CLI subcommands and API endpoints.
+
+**Architecture:** Flat peer methods following the existing pattern — each method gets a CLI subcommand (`src/cli/{method}_cmd.rs`), API handler (`src/api/{method}.rs`), core logic (`src/semantic/{method}_chunk.rs`), types file (`src/semantic/{method}_types.rs`), and LLM prompts (`src/llm/{method}.rs`). Registration in `src/main.rs` (Commands enum + match), `src/cli/mod.rs`, `src/api/mod.rs` (router + module), and `src/semantic/mod.rs` (module declaration).
+
+**Tech Stack:** Rust 2024, clap 4.5 (derive), serde/serde_json, tokio, reqwest, axum, existing `EmbeddingProvider` trait, existing `CompletionClient` for LLM calls.
+
+**Spec:** `docs/superpowers/specs/2026-04-10-new-chunking-methods-design.md`
+
+---
+
+## File Map
+
+### Quality Metrics Module (Task 1)
+- Create: `src/semantic/quality_metrics.rs` — 5 metric implementations + `evaluate_chunks` function
+- Create: `src/api/evaluate.rs` — `POST /api/v1/evaluate` handler
+- Modify: `src/semantic/mod.rs` — add `pub mod quality_metrics;`
+- Modify: `src/api/mod.rs` — add `pub mod evaluate;` + route
+- Test: unit tests inline in `quality_metrics.rs`
+
+### Intent-Driven Chunking (Task 2)
+- Create: `src/semantic/intent_types.rs` — IntentResult, IntentChunk, PredictedIntent, IntentType
+- Create: `src/semantic/intent_chunk.rs` — DP algorithm, alignment scoring, pipeline orchestration
+- Create: `src/llm/intents.rs` — intent generation prompt + JSON schema
+- Create: `src/cli/intent_cmd.rs` — CLI subcommand
+- Create: `src/api/intent.rs` — API handler
+- Modify: `src/semantic/mod.rs` — add module declarations + re-export `intent_chunk`
+- Modify: `src/llm/mod.rs` — add `pub mod intents;`
+- Modify: `src/cli/mod.rs` — add `pub mod intent_cmd;`
+- Modify: `src/api/mod.rs` — add `pub mod intent;` + route
+- Modify: `src/main.rs` — add `Intent` variant + match arm
+- Test: unit tests inline in `intent_chunk.rs`
+
+### Enriched Chunking (Task 3)
+- Create: `src/semantic/enriched_types.rs` — EnrichedResult, EnrichedChunk, TypedEntity, MergeRecord
+- Create: `src/semantic/enriched_chunk.rs` — pipeline orchestration, initial grouping, key-based recombination
+- Create: `src/llm/enrichment.rs` — 7-field enrichment prompt, JSON schema, rolling key logic
+- Create: `src/cli/enriched_cmd.rs` — CLI subcommand
+- Create: `src/api/enriched.rs` — API handler
+- Modify: `src/semantic/mod.rs` — add module declarations
+- Modify: `src/llm/mod.rs` — add `pub mod enrichment;`
+- Modify: `src/cli/mod.rs` — add `pub mod enriched_cmd;`
+- Modify: `src/api/mod.rs` — add `pub mod enriched;` + route
+- Modify: `src/main.rs` — add `Enriched` variant + match arm
+- Test: unit tests inline in `enriched_chunk.rs`
+
+### Topology-Aware Chunking (Task 4)
+- Create: `src/semantic/sir.rs` — SIR data structures (SirNode, SirEdge, Sir, SirNodeType, SirEdgeType)
+- Create: `src/semantic/topo_types.rs` — TopoResult, TopoChunk, SectionClassification, SectionClass
+- Create: `src/semantic/topo_chunk.rs` — SIR builder, assembly, pipeline orchestration
+- Create: `src/llm/topo_agents.rs` — Inspector + Refiner prompts and JSON schemas
+- Create: `src/cli/topo_cmd.rs` — CLI subcommand
+- Create: `src/api/topo.rs` — API handler
+- Modify: `src/semantic/mod.rs` — add module declarations
+- Modify: `src/llm/mod.rs` — add `pub mod topo_agents;`
+- Modify: `src/cli/mod.rs` — add `pub mod topo_cmd;`
+- Modify: `src/api/mod.rs` — add `pub mod topo;` + route
+- Modify: `src/main.rs` — add `Topo` variant + match arm
+- Test: unit tests inline in `topo_chunk.rs`
+
+### Adaptive Chunking (Task 5)
+- Create: `src/semantic/adaptive_types.rs` — AdaptiveResult, AdaptiveReport, CandidateScore, ScreeningDecision
+- Create: `src/semantic/adaptive_chunk.rs` — orchestrator: pre-screening, candidate dispatch, scoring, selection
+- Create: `src/cli/adaptive_cmd.rs` — CLI subcommand
+- Create: `src/api/adaptive.rs` — API handler
+- Modify: `src/semantic/mod.rs` — add module declarations
+- Modify: `src/cli/mod.rs` — add `pub mod adaptive_cmd;`
+- Modify: `src/api/mod.rs` — add `pub mod adaptive;` + route
+- Modify: `src/main.rs` — add `Adaptive` variant + match arm
+- Test: unit tests inline in `adaptive_chunk.rs`
+
+---
+
+## Task 1: Quality Metrics Module
+
+The standalone module that scores any chunking output on 5 intrinsic dimensions. Used by Adaptive and available via API for benchmarking.
+
+**Files:**
+- Create: `src/semantic/quality_metrics.rs`
+- Create: `src/api/evaluate.rs`
+- Modify: `src/semantic/mod.rs`
+- Modify: `src/api/mod.rs`
+
+### Step 1.1: Write types and size compliance metric
+
+- [ ] **Create `src/semantic/quality_metrics.rs` with core types + SC metric**
+
+```rust
+//! Intrinsic quality metrics for evaluating chunking output.
+//!
+//! Five metrics scored 0.0–1.0:
+//! - Size Compliance (SC): fraction of chunks within target token bounds
+//! - Intrachunk Cohesion (ICC): semantic unity within each chunk
+//! - Contextual Coherence (DCC): smooth transitions between adjacent chunks
+//! - Block Integrity (BI): structural elements preserved intact
+//! - Reference Completeness (RC): entity-pronoun chains not severed
+
+use std::collections::HashSet;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::embeddings::EmbeddingProvider;
+
+/// Quality scores for a set of chunks (each 0.0–1.0).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QualityMetrics {
+    pub size_compliance: f64,
+    pub intrachunk_cohesion: f64,
+    pub contextual_coherence: f64,
+    pub block_integrity: f64,
+    pub reference_completeness: f64,
+    pub composite: f64,
+}
+
+/// Weights for combining the five metrics into a composite score.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricWeights {
+    pub sc: f64,
+    pub icc: f64,
+    pub dcc: f64,
+    pub bi: f64,
+    pub rc: f64,
+}
+
+impl Default for MetricWeights {
+    fn default() -> Self {
+        Self {
+            sc: 0.20,
+            icc: 0.20,
+            dcc: 0.20,
+            bi: 0.20,
+            rc: 0.20,
+        }
+    }
+}
+
+/// A chunk presented for evaluation (minimal interface — works with any method's output).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChunkForEval {
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+}
+
+/// Configuration for quality evaluation.
+#[derive(Debug, Clone)]
+pub struct MetricConfig {
+    pub soft_budget: usize,
+    pub hard_budget: usize,
+    pub weights: MetricWeights,
+}
+
+impl Default for MetricConfig {
+    fn default() -> Self {
+        Self {
+            soft_budget: 512,
+            hard_budget: 768,
+            weights: MetricWeights::default(),
+        }
+    }
+}
+
+/// Estimate token count for a text (whitespace splitting, same as core::merge).
+fn estimate_tokens(text: &str) -> usize {
+    text.split_whitespace().count()
+}
+
+/// Compute composite score from individual metrics.
+pub fn composite_score(metrics: &QualityMetrics, weights: &MetricWeights) -> f64 {
+    weights.sc * metrics.size_compliance
+        + weights.icc * metrics.intrachunk_cohesion
+        + weights.dcc * metrics.contextual_coherence
+        + weights.bi * metrics.block_integrity
+        + weights.rc * metrics.reference_completeness
+}
+
+// ── Size Compliance ────────────────────────────────────────────────
+
+/// SC = count(chunks where soft_budget * 0.5 <= tokens <= hard_budget) / total.
+pub fn size_compliance(chunks: &[ChunkForEval], soft_budget: usize, hard_budget: usize) -> f64 {
+    if chunks.is_empty() {
+        return 1.0;
+    }
+    let min_tokens = soft_budget / 2;
+    let compliant = chunks
+        .iter()
+        .filter(|c| {
+            let tokens = estimate_tokens(&c.text);
+            tokens >= min_tokens && tokens <= hard_budget
+        })
+        .count();
+    compliant as f64 / chunks.len() as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_size_compliance_all_compliant() {
+        let chunks = vec![
+            ChunkForEval { text: "word ".repeat(300), offset_start: 0, offset_end: 100 },
+            ChunkForEval { text: "word ".repeat(500), offset_start: 100, offset_end: 200 },
+        ];
+        let sc = size_compliance(&chunks, 512, 768);
+        assert!((sc - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_size_compliance_too_small() {
+        let chunks = vec![
+            ChunkForEval { text: "short text".to_string(), offset_start: 0, offset_end: 10 },
+            ChunkForEval { text: "word ".repeat(400), offset_start: 10, offset_end: 200 },
+        ];
+        let sc = size_compliance(&chunks, 512, 768);
+        assert!((sc - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_size_compliance_empty() {
+        let sc = size_compliance(&[], 512, 768);
+        assert!((sc - 1.0).abs() < f64::EPSILON);
+    }
+}
+```
+
+- [ ] **Register module in `src/semantic/mod.rs`**
+
+Add after the existing module declarations (line ~18 in `src/semantic/mod.rs`):
+
+```rust
+pub mod quality_metrics;
+```
+
+- [ ] **Run `cargo check` to verify compilation**
+
+Run: `cargo check 2>&1 | head -20`
+Expected: no errors (warnings about unused imports are OK at this stage)
+
+- [ ] **Run tests**
+
+Run: `cargo test quality_metrics -- --nocapture 2>&1 | tail -20`
+Expected: 3 tests pass
+
+- [ ] **Commit**
+
+```bash
+git add src/semantic/quality_metrics.rs src/semantic/mod.rs
+git commit -m "feat(quality-metrics): add types + size compliance metric"
+```
+
+### Step 1.2: Add block integrity metric
+
+- [ ] **Add BI metric to `src/semantic/quality_metrics.rs`**
+
+Append before the `#[cfg(test)]` module:
+
+```rust
+// ── Block Integrity ────────────────────────────────────────────────
+
+/// BI = count(structural_elements_fully_contained) / total_structural_elements.
+///
+/// Structural elements are identified by re-parsing the original text.
+/// A structural element is "fully contained" if its byte range falls entirely
+/// within a single chunk's [offset_start, offset_end) range.
+pub fn block_integrity(
+    original_text: &str,
+    chunks: &[ChunkForEval],
+) -> f64 {
+    use super::blocks::{split_blocks, BlockKind};
+
+    let blocks = split_blocks(original_text);
+    let structural: Vec<_> = blocks
+        .iter()
+        .filter(|b| matches!(b.kind, BlockKind::Table | BlockKind::CodeBlock | BlockKind::List | BlockKind::BlockQuote))
+        .collect();
+
+    if structural.is_empty() {
+        return 1.0; // No structural elements = perfect integrity
+    }
+
+    let contained = structural
+        .iter()
+        .filter(|block| {
+            let block_start = block.offset;
+            let block_end = block.offset + block.text.len();
+            chunks.iter().any(|c| c.offset_start <= block_start && c.offset_end >= block_end)
+        })
+        .count();
+
+    contained as f64 / structural.len() as f64
+}
+```
+
+Add test inside the `#[cfg(test)]` module:
+
+```rust
+    #[test]
+    fn test_block_integrity_no_structural() {
+        let text = "Just a paragraph of plain text without any tables or code.";
+        let chunks = vec![
+            ChunkForEval { text: text.to_string(), offset_start: 0, offset_end: text.len() },
+        ];
+        let bi = block_integrity(text, &chunks);
+        assert!((bi - 1.0).abs() < f64::EPSILON);
+    }
+```
+
+- [ ] **Run tests**
+
+Run: `cargo test quality_metrics -- --nocapture 2>&1 | tail -20`
+Expected: 4 tests pass
+
+- [ ] **Commit**
+
+```bash
+git add src/semantic/quality_metrics.rs
+git commit -m "feat(quality-metrics): add block integrity metric"
+```
+
+### Step 1.3: Add reference completeness metric
+
+- [ ] **Add RC metric to `src/semantic/quality_metrics.rs`**
+
+Append before the `#[cfg(test)]` module:
+
+```rust
+// ── Reference Completeness ─────────────────────────────────────────
+
+/// RC = 1.0 - (orphan_count / total_boundary_count).
+///
+/// An "orphan" is a chunk that starts with a pronoun or demonstrative
+/// whose antecedent is likely in the previous chunk (i.e., the split
+/// severed a coreference chain).
+pub fn reference_completeness(chunks: &[ChunkForEval]) -> f64 {
+    if chunks.len() <= 1 {
+        return 1.0;
+    }
+
+    let boundary_count = chunks.len() - 1;
+    let mut orphan_count = 0usize;
+
+    // English pronouns and demonstratives that signal orphan risk
+    let orphan_starters: &[&str] = &[
+        "it ", "its ", "they ", "them ", "their ", "he ", "him ", "his ",
+        "she ", "her ", "this ", "that ", "these ", "those ", "such ",
+    ];
+
+    for chunk in chunks.iter().skip(1) {
+        let lower = chunk.text.trim_start().to_lowercase();
+        if orphan_starters.iter().any(|s| lower.starts_with(s)) {
+            orphan_count += 1;
+        }
+    }
+
+    1.0 - (orphan_count as f64 / boundary_count as f64)
+}
+```
+
+Add tests:
+
+```rust
+    #[test]
+    fn test_reference_completeness_no_orphans() {
+        let chunks = vec![
+            ChunkForEval { text: "Compound XR-7742 inhibits serotonin.".to_string(), offset_start: 0, offset_end: 36 },
+            ChunkForEval { text: "The dosing protocol requires titration.".to_string(), offset_start: 36, offset_end: 75 },
+        ];
+        let rc = reference_completeness(&chunks);
+        assert!((rc - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_reference_completeness_with_orphan() {
+        let chunks = vec![
+            ChunkForEval { text: "Compound XR-7742 inhibits serotonin.".to_string(), offset_start: 0, offset_end: 36 },
+            ChunkForEval { text: "It also blocks dopamine reuptake.".to_string(), offset_start: 36, offset_end: 68 },
+        ];
+        let rc = reference_completeness(&chunks);
+        assert!((rc - 0.0).abs() < f64::EPSILON); // 1 orphan / 1 boundary = 0
+    }
+```
+
+- [ ] **Run tests**
+
+Run: `cargo test quality_metrics -- --nocapture 2>&1 | tail -20`
+Expected: 6 tests pass
+
+- [ ] **Commit**
+
+```bash
+git add src/semantic/quality_metrics.rs
+git commit -m "feat(quality-metrics): add reference completeness metric"
+```
+
+### Step 1.4: Add embedding-dependent metrics (ICC + DCC) and evaluate_chunks
+
+- [ ] **Add ICC, DCC, and the main `evaluate_chunks` function**
+
+Append before the `#[cfg(test)]` module:
+
+```rust
+// ── Intrachunk Cohesion (ICC) ──────────────────────────────────────
+
+/// ICC: mean cosine similarity of sentence embeddings to chunk centroid.
+/// Requires an embedding provider.
+pub async fn intrachunk_cohesion<P: EmbeddingProvider>(
+    chunks: &[ChunkForEval],
+    provider: &P,
+) -> Result<f64> {
+    use super::sentence::split_sentences;
+
+    if chunks.is_empty() {
+        return Ok(1.0);
+    }
+
+    let mut cohesion_scores = Vec::with_capacity(chunks.len());
+
+    for chunk in chunks {
+        let sentences: Vec<String> = split_sentences(&chunk.text)
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        if sentences.len() <= 1 {
+            cohesion_scores.push(1.0); // Single-sentence chunk is perfectly cohesive
+            continue;
+        }
+
+        // Embed all sentences + the full chunk text
+        let mut texts: Vec<&str> = sentences.iter().map(|s| s.as_str()).collect();
+        texts.push(&chunk.text);
+
+        let embeddings = provider.embed(&texts).await?;
+        let chunk_emb = embeddings.last().unwrap();
+
+        let mut sim_sum = 0.0;
+        for emb in &embeddings[..embeddings.len() - 1] {
+            sim_sum += cosine_similarity(emb, chunk_emb);
+        }
+        cohesion_scores.push(sim_sum / sentences.len() as f64);
+    }
+
+    Ok(cohesion_scores.iter().sum::<f64>() / cohesion_scores.len() as f64)
+}
+
+// ── Contextual Coherence (DCC) ─────────────────────────────────────
+
+/// DCC: mean cosine similarity between adjacent chunk embeddings.
+pub async fn contextual_coherence<P: EmbeddingProvider>(
+    chunks: &[ChunkForEval],
+    provider: &P,
+) -> Result<f64> {
+    if chunks.len() <= 1 {
+        return Ok(1.0);
+    }
+
+    let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
+    let embeddings = provider.embed(&texts).await?;
+
+    let mut sim_sum = 0.0;
+    for i in 0..embeddings.len() - 1 {
+        sim_sum += cosine_similarity(&embeddings[i], &embeddings[i + 1]);
+    }
+
+    Ok(sim_sum / (embeddings.len() - 1) as f64)
+}
+
+/// Cosine similarity between two vectors.
+fn cosine_similarity(a: &[f64], b: &[f64]) -> f64 {
+    let dot: f64 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_a: f64 = a.iter().map(|x| x * x).sum::<f64>().sqrt();
+    let norm_b: f64 = b.iter().map(|x| x * x).sum::<f64>().sqrt();
+    if norm_a == 0.0 || norm_b == 0.0 {
+        return 0.0;
+    }
+    dot / (norm_a * norm_b)
+}
+
+// ── Main evaluation function ───────────────────────────────────────
+
+/// Evaluate a set of chunks against the original text using all 5 metrics.
+pub async fn evaluate_chunks<P: EmbeddingProvider>(
+    original_text: &str,
+    chunks: &[ChunkForEval],
+    provider: &P,
+    config: &MetricConfig,
+) -> Result<QualityMetrics> {
+    let sc = size_compliance(chunks, config.soft_budget, config.hard_budget);
+    let bi = block_integrity(original_text, chunks);
+    let rc = reference_completeness(chunks);
+    let icc = intrachunk_cohesion(chunks, provider).await?;
+    let dcc = contextual_coherence(chunks, provider).await?;
+
+    let mut metrics = QualityMetrics {
+        size_compliance: sc,
+        intrachunk_cohesion: icc,
+        contextual_coherence: dcc,
+        block_integrity: bi,
+        reference_completeness: rc,
+        composite: 0.0,
+    };
+    metrics.composite = composite_score(&metrics, &config.weights);
+    Ok(metrics)
+}
+```
+
+- [ ] **Run `cargo check`**
+
+Run: `cargo check 2>&1 | head -20`
+Expected: compiles (ICC/DCC are async, tested via integration tests with mock provider)
+
+- [ ] **Commit**
+
+```bash
+git add src/semantic/quality_metrics.rs
+git commit -m "feat(quality-metrics): add ICC, DCC metrics + evaluate_chunks function"
+```
+
+### Step 1.5: Add /api/v1/evaluate endpoint
+
+- [ ] **Create `src/api/evaluate.rs`**
+
+```rust
+//! POST /api/v1/evaluate handler.
+//!
+//! Accepts pre-chunked output and returns quality metrics.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use serde::{Deserialize, Serialize};
+
+use crate::embeddings::ollama::OllamaProvider;
+use crate::embeddings::openai::OpenAiProvider;
+use crate::embeddings::onnx::OnnxProvider;
+use crate::embeddings::cloudflare::{CloudflareProvider, resolve_cloudflare_credentials};
+use crate::embeddings::oauth::{OAuthProvider, resolve_oauth_credentials};
+use crate::embeddings::EmbeddingProvider;
+use crate::semantic::quality_metrics::{
+    ChunkForEval, MetricConfig, MetricWeights, QualityMetrics, evaluate_chunks,
+};
+
+use super::AppState;
+use super::errors::ApiError;
+use super::semantic::{ProviderParam, validate_base_url};
+
+fn default_provider() -> ProviderParam {
+    ProviderParam::Ollama
+}
+fn default_soft_budget() -> usize {
+    512
+}
+fn default_hard_budget() -> usize {
+    768
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EvaluateRequest {
+    /// The original document text.
+    pub text: String,
+    /// Pre-chunked output to evaluate.
+    pub chunks: Vec<ChunkForEval>,
+    #[serde(default = "default_provider")]
+    pub provider: ProviderParam,
+    pub model: Option<String>,
+    pub api_key: Option<String>,
+    pub base_url: Option<String>,
+    pub model_path: Option<String>,
+    pub cf_auth_token: Option<String>,
+    pub cf_account_id: Option<String>,
+    pub cf_ai_gateway: Option<String>,
+    pub oauth_token_url: Option<String>,
+    pub oauth_client_id: Option<String>,
+    pub oauth_client_secret: Option<String>,
+    pub oauth_scope: Option<String>,
+    pub oauth_base_url: Option<String>,
+    #[serde(default)]
+    pub danger_accept_invalid_certs: bool,
+    #[serde(default = "default_soft_budget")]
+    pub soft_budget: usize,
+    #[serde(default = "default_hard_budget")]
+    pub hard_budget: usize,
+    pub metric_weights: Option<MetricWeights>,
+}
+
+#[derive(Serialize)]
+pub struct EvaluateResponse {
+    pub metrics: QualityMetrics,
+    pub chunk_count: usize,
+}
+
+pub async fn evaluate_handler(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<EvaluateRequest>,
+) -> Result<Json<EvaluateResponse>, ApiError> {
+    if let Some(ref base_url) = req.base_url {
+        validate_base_url(base_url, state.allow_private_urls)?;
+    }
+
+    let config = MetricConfig {
+        soft_budget: req.soft_budget,
+        hard_budget: req.hard_budget,
+        weights: req.metric_weights.unwrap_or_default(),
+    };
+
+    let metrics = match req.provider {
+        ProviderParam::Ollama => {
+            let provider = OllamaProvider::new(req.base_url.clone(), req.model.clone())?;
+            evaluate_chunks(&req.text, &req.chunks, &provider, &config).await?
+        }
+        ProviderParam::Openai => {
+            let api_key = resolve_openai_key(&req.api_key)?;
+            let provider = OpenAiProvider::new(api_key, req.base_url.clone(), req.model.clone())?;
+            evaluate_chunks(&req.text, &req.chunks, &provider, &config).await?
+        }
+        ProviderParam::Onnx => {
+            let model_path = req
+                .model_path
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("model_path is required for onnx provider"))?;
+            let provider = OnnxProvider::new(model_path)?;
+            evaluate_chunks(&req.text, &req.chunks, &provider, &config).await?
+        }
+        ProviderParam::Cloudflare => {
+            let (token, account_id, gateway) = resolve_cloudflare_credentials(
+                &req.cf_auth_token,
+                &req.cf_account_id,
+                &req.cf_ai_gateway,
+            )?;
+            let provider = CloudflareProvider::new(token, account_id, req.model.clone(), gateway)?;
+            provider.verify_token().await?;
+            evaluate_chunks(&req.text, &req.chunks, &provider, &config).await?
+        }
+        ProviderParam::Oauth => {
+            let creds = resolve_oauth_credentials(
+                &req.oauth_token_url,
+                &req.oauth_client_id,
+                &req.oauth_client_secret,
+                &req.oauth_scope,
+                &req.oauth_base_url,
+                &req.model,
+            )?;
+            let provider = OAuthProvider::new(
+                creds.token_url,
+                creds.client_id,
+                creds.client_secret,
+                creds.scope,
+                creds.base_url,
+                creds.model,
+                req.danger_accept_invalid_certs,
+            )?;
+            provider.verify_credentials().await?;
+            evaluate_chunks(&req.text, &req.chunks, &provider, &config).await?
+        }
+    };
+
+    let chunk_count = req.chunks.len();
+    Ok(Json(EvaluateResponse {
+        metrics,
+        chunk_count,
+    }))
+}
+
+fn resolve_openai_key(flag: &Option<String>) -> anyhow::Result<String> {
+    if let Some(key) = flag {
+        return Ok(key.clone());
+    }
+    if let Ok(key) = std::env::var("OPENAI_API_KEY")
+        && !key.is_empty()
+    {
+        return Ok(key);
+    }
+    if let Ok(content) = std::fs::read_to_string(".env.openai") {
+        for line in content.lines() {
+            let line = line.trim();
+            if let Some(val) = line.strip_prefix("OPENAI_API_KEY=") {
+                let val = val.trim();
+                if !val.is_empty() {
+                    return Ok(val.to_string());
+                }
+            }
+        }
+    }
+    anyhow::bail!("OpenAI API key not found.")
+}
+```
+
+- [ ] **Register in `src/api/mod.rs`**
+
+Add `pub mod evaluate;` after the existing module declarations (after line 9 `pub mod types;`).
+
+Add route to the router (after the `/api/v1/merge` route, before `.layer(...)`):
+
+```rust
+        .route(
+            "/api/v1/evaluate",
+            axum::routing::post(evaluate::evaluate_handler),
+        )
+```
+
+- [ ] **Run `cargo check`**
+
+Run: `cargo check 2>&1 | head -20`
+Expected: compiles
+
+- [ ] **Commit**
+
+```bash
+git add src/api/evaluate.rs src/api/mod.rs
+git commit -m "feat(quality-metrics): add POST /api/v1/evaluate endpoint"
+```
+
+---
+
+## Task 2: Intent-Driven Chunking
+
+LLM predicts user queries → DP finds globally optimal chunk boundaries maximizing query-chunk alignment.
+
+**Files:**
+- Create: `src/semantic/intent_types.rs`
+- Create: `src/llm/intents.rs`
+- Create: `src/semantic/intent_chunk.rs`
+- Create: `src/cli/intent_cmd.rs`
+- Create: `src/api/intent.rs`
+- Modify: `src/semantic/mod.rs`, `src/llm/mod.rs`, `src/cli/mod.rs`, `src/api/mod.rs`, `src/main.rs`
+
+### Step 2.1: Create intent types
+
+- [ ] **Create `src/semantic/intent_types.rs`**
+
+```rust
+//! Data types for intent-driven chunking.
+
+use serde::{Deserialize, Serialize};
+
+/// The type of information need a query represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IntentType {
+    Factual,
+    Procedural,
+    Conceptual,
+    Comparative,
+}
+
+/// A predicted user query generated by the LLM.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PredictedIntent {
+    pub query: String,
+    pub intent_type: IntentType,
+    /// Chunk indices that best align with this intent (populated after assembly).
+    #[serde(default)]
+    pub matched_chunks: Vec<usize>,
+}
+
+/// A single chunk produced by intent-driven chunking.
+#[derive(Debug, Clone, Serialize)]
+pub struct IntentChunk {
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+    pub token_estimate: usize,
+    /// Index into the intents vector for the best-matching intent.
+    pub best_intent: usize,
+    /// Cosine similarity between chunk centroid and best intent embedding.
+    pub alignment_score: f64,
+    /// Heading ancestry path at the start of this chunk.
+    pub heading_path: Vec<String>,
+}
+
+/// Result of intent-driven chunking.
+#[derive(Debug)]
+pub struct IntentResult {
+    pub chunks: Vec<IntentChunk>,
+    pub intents: Vec<PredictedIntent>,
+    /// Mean alignment score across all chunks.
+    pub partition_score: f64,
+    /// Number of blocks processed.
+    pub block_count: usize,
+}
+```
+
+- [ ] **Register in `src/semantic/mod.rs`**
+
+Add after the existing module declarations:
+
+```rust
+pub mod intent_types;
+```
+
+- [ ] **Run `cargo check`**
+
+Run: `cargo check 2>&1 | head -20`
+Expected: compiles
+
+- [ ] **Commit**
+
+```bash
+git add src/semantic/intent_types.rs src/semantic/mod.rs
+git commit -m "feat(intent): add intent chunking data types"
+```
+
+### Step 2.2: Create LLM intent generation
+
+- [ ] **Create `src/llm/intents.rs`**
+
+```rust
+//! LLM-based intent generation for intent-driven chunking.
+//!
+//! Generates predicted user queries that represent likely information needs
+//! for a given document.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use super::CompletionClient;
+use crate::semantic::intent_types::{IntentType, PredictedIntent};
+
+#[derive(Deserialize)]
+struct IntentResponse {
+    intents: Vec<IntentEntry>,
+}
+
+#[derive(Deserialize)]
+struct IntentEntry {
+    query: String,
+    intent_type: IntentType,
+}
+
+const SYSTEM_PROMPT: &str = "\
+You are an information needs prediction engine. Given a document, generate diverse \
+user queries that someone might search for when looking for information in this document.
+
+Rules:
+- Generate queries that represent realistic information needs
+- Cover different aspects of the document (not just the introduction)
+- Include a mix of factual, procedural, conceptual, and comparative queries
+- Queries should be specific enough to match a single section or paragraph
+- Each query should be self-contained (understandable without the document)
+- Avoid duplicate or near-duplicate queries
+- Prioritize queries that would benefit from precise chunk retrieval";
+
+fn json_schema(max_intents: usize) -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "intents": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "A realistic user query about this document"
+                        },
+                        "intent_type": {
+                            "type": "string",
+                            "enum": ["factual", "procedural", "conceptual", "comparative"],
+                            "description": "The type of information need"
+                        }
+                    },
+                    "required": ["query", "intent_type"],
+                    "additionalProperties": false
+                },
+                "maxItems": max_intents
+            }
+        },
+        "required": ["intents"],
+        "additionalProperties": false
+    })
+}
+
+/// Generate predicted user intents for a document.
+pub async fn generate_intents(
+    client: &CompletionClient,
+    text: &str,
+    max_intents: usize,
+) -> Result<Vec<PredictedIntent>> {
+    let user_prompt = format!(
+        "Generate up to {max_intents} diverse user queries for this document:\n\n{text}"
+    );
+
+    let response = client
+        .complete_json(SYSTEM_PROMPT, &user_prompt, json_schema(max_intents))
+        .await
+        .context("Intent generation failed")?;
+
+    let parsed: IntentResponse =
+        serde_json::from_str(&response).context("Failed to parse intent response")?;
+
+    Ok(parsed
+        .intents
+        .into_iter()
+        .map(|e| PredictedIntent {
+            query: e.query,
+            intent_type: e.intent_type,
+            matched_chunks: vec![],
+        })
+        .collect())
+}
+```
+
+- [ ] **Register in `src/llm/mod.rs`**
+
+Add after the existing module declarations (line 7):
+
+```rust
+pub mod intents;
+```
+
+- [ ] **Run `cargo check`**
+
+Run: `cargo check 2>&1 | head -20`
+Expected: compiles
+
+- [ ] **Commit**
+
+```bash
+git add src/llm/intents.rs src/llm/mod.rs
+git commit -m "feat(intent): add LLM intent generation"
+```
+
+### Step 2.3: Create intent chunking pipeline (DP + alignment scoring)
+
+- [ ] **Create `src/semantic/intent_chunk.rs`**
+
+```rust
+//! Intent-driven chunking pipeline.
+//!
+//! Pipeline: blocks → LLM intent generation → embed blocks + intents →
+//!           DP alignment optimization → IntentResult
+
+use anyhow::{Result, bail};
+
+use crate::embeddings::EmbeddingProvider;
+use crate::llm::CompletionClient;
+use crate::llm::intents::generate_intents;
+
+use super::blocks::{split_blocks, BlockKind};
+use super::enrichment::heading_context::compute_heading_paths;
+use super::intent_types::{IntentChunk, IntentResult, PredictedIntent};
+use super::sentence::split_sentences;
+
+/// Configuration for intent-driven chunking.
+#[derive(Debug, Clone)]
+pub struct IntentConfig {
+    /// Maximum number of intents to generate.
+    pub max_intents: usize,
+    /// Soft token budget per chunk (preferred minimum).
+    pub soft_budget: usize,
+    /// Hard token ceiling per chunk.
+    pub hard_budget: usize,
+}
+
+impl Default for IntentConfig {
+    fn default() -> Self {
+        Self {
+            max_intents: 20,
+            soft_budget: 512,
+            hard_budget: 768,
+        }
+    }
+}
+
+/// Estimate token count (whitespace splitting).
+fn estimate_tokens(text: &str) -> usize {
+    text.split_whitespace().count()
+}
+
+/// Cosine similarity between two vectors.
+fn cosine_similarity(a: &[f64], b: &[f64]) -> f64 {
+    let dot: f64 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_a: f64 = a.iter().map(|x| x * x).sum::<f64>().sqrt();
+    let norm_b: f64 = b.iter().map(|x| x * x).sum::<f64>().sqrt();
+    if norm_a == 0.0 || norm_b == 0.0 {
+        return 0.0;
+    }
+    dot / (norm_a * norm_b)
+}
+
+/// Compute centroid embedding (mean of block embeddings in range).
+fn centroid(embeddings: &[Vec<f64>], start: usize, end: usize) -> Vec<f64> {
+    let count = end - start;
+    if count == 0 {
+        return vec![];
+    }
+    let dim = embeddings[start].len();
+    let mut result = vec![0.0; dim];
+    for emb in &embeddings[start..end] {
+        for (i, val) in emb.iter().enumerate() {
+            result[i] += val;
+        }
+    }
+    for val in &mut result {
+        *val /= count as f64;
+    }
+    result
+}
+
+/// Best alignment score for a chunk (max cosine sim to any intent embedding).
+fn chunk_alignment(
+    block_embeddings: &[Vec<f64>],
+    intent_embeddings: &[Vec<f64>],
+    start: usize,
+    end: usize,
+) -> (f64, usize) {
+    let cent = centroid(block_embeddings, start, end);
+    if cent.is_empty() || intent_embeddings.is_empty() {
+        return (0.0, 0);
+    }
+    let mut best_score = f64::NEG_INFINITY;
+    let mut best_idx = 0;
+    for (i, intent_emb) in intent_embeddings.iter().enumerate() {
+        let sim = cosine_similarity(&cent, intent_emb);
+        if sim > best_score {
+            best_score = sim;
+            best_idx = i;
+        }
+    }
+    (best_score, best_idx)
+}
+
+/// Run the intent-driven chunking pipeline on markdown text.
+pub async fn intent_chunk<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: &CompletionClient,
+    config: &IntentConfig,
+) -> Result<IntentResult> {
+    let blocks = split_blocks(text);
+    intent_chunk_from_blocks(text, &blocks, provider, llm_client, config).await
+}
+
+/// Run the intent-driven chunking pipeline on plain text.
+pub async fn intent_chunk_plain<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: &CompletionClient,
+    config: &IntentConfig,
+) -> Result<IntentResult> {
+    let sentences = split_sentences(text);
+    let blocks: Vec<super::blocks::Block<'_>> = sentences
+        .iter()
+        .map(|s| super::blocks::Block {
+            text: s,
+            offset: s.as_ptr() as usize - text.as_ptr() as usize,
+            kind: BlockKind::Sentence,
+        })
+        .collect();
+    intent_chunk_from_blocks(text, &blocks, provider, llm_client, config).await
+}
+
+async fn intent_chunk_from_blocks<'a, P: EmbeddingProvider>(
+    _text: &str,
+    blocks: &[super::blocks::Block<'a>],
+    provider: &P,
+    llm_client: &CompletionClient,
+    config: &IntentConfig,
+) -> Result<IntentResult> {
+    if blocks.is_empty() {
+        return Ok(IntentResult {
+            chunks: vec![],
+            intents: vec![],
+            partition_score: 0.0,
+            block_count: 0,
+        });
+    }
+
+    let block_count = blocks.len();
+
+    // Step 1: Compute heading paths
+    let (heading_paths, _heading_terms) = compute_heading_paths(blocks);
+
+    // Step 2: Generate intents from full text
+    let full_text: String = blocks.iter().map(|b| b.text).collect::<Vec<_>>().join("\n");
+    let mut intents = generate_intents(llm_client, &full_text, config.max_intents).await?;
+
+    if intents.is_empty() {
+        bail!("LLM generated no intents for the document");
+    }
+
+    // Step 3: Embed blocks
+    let block_texts: Vec<&str> = blocks.iter().map(|b| b.text).collect();
+    let block_embeddings = provider.embed(&block_texts).await?;
+
+    // Step 4: Embed intents
+    let intent_texts: Vec<&str> = intents.iter().map(|i| i.query.as_str()).collect();
+    let intent_embeddings = provider.embed(&intent_texts).await?;
+
+    // Step 5: Compute token estimates per block
+    let block_tokens: Vec<usize> = blocks.iter().map(|b| estimate_tokens(b.text)).collect();
+    let avg_block_tokens = block_tokens.iter().sum::<usize>() as f64 / block_tokens.len() as f64;
+
+    // Compute min/max blocks per chunk from budgets
+    let min_blocks = ((config.soft_budget as f64 * 0.5 / avg_block_tokens).ceil() as usize).max(1);
+    let max_blocks = ((config.hard_budget as f64 / avg_block_tokens).ceil() as usize)
+        .max(min_blocks + 1)
+        .min(block_count);
+
+    // Step 6: Dynamic programming
+    // dp[i] = (best_score, backtrack_index) for blocks 0..i
+    let n = block_count;
+    let mut dp = vec![(f64::NEG_INFINITY, 0usize); n + 1];
+    dp[0] = (0.0, 0);
+
+    for i in 1..=n {
+        for chunk_size in min_blocks..=max_blocks {
+            if chunk_size > i {
+                break;
+            }
+            let start = i - chunk_size;
+            if dp[start].0 == f64::NEG_INFINITY {
+                continue;
+            }
+            let (alignment, _) = chunk_alignment(
+                &block_embeddings,
+                &intent_embeddings,
+                start,
+                i,
+            );
+            let score = dp[start].0 + alignment;
+            if score > dp[i].0 {
+                dp[i] = (score, start);
+            }
+        }
+    }
+
+    // Backtrack to recover partition
+    let mut boundaries = Vec::new();
+    let mut pos = n;
+    while pos > 0 {
+        let start = dp[pos].1;
+        boundaries.push((start, pos));
+        pos = start;
+    }
+    boundaries.reverse();
+
+    // Step 7: Build chunks
+    let mut chunks = Vec::with_capacity(boundaries.len());
+    for (start, end) in &boundaries {
+        let chunk_text: String = blocks[*start..*end]
+            .iter()
+            .map(|b| b.text)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let offset_start = blocks[*start].offset;
+        let offset_end = blocks[end - 1].offset + blocks[end - 1].text.len();
+        let token_est = estimate_tokens(&chunk_text);
+
+        let (alignment, best_intent_idx) = chunk_alignment(
+            &block_embeddings,
+            &intent_embeddings,
+            *start,
+            *end,
+        );
+
+        let heading_path = heading_paths[*start].clone();
+
+        chunks.push(IntentChunk {
+            text: chunk_text,
+            offset_start,
+            offset_end,
+            token_estimate: token_est,
+            best_intent: best_intent_idx,
+            alignment_score: alignment,
+            heading_path,
+        });
+    }
+
+    // Populate intent -> chunk mappings
+    for (chunk_idx, chunk) in chunks.iter().enumerate() {
+        if chunk.best_intent < intents.len() {
+            intents[chunk_idx % intents.len()].matched_chunks.push(chunk_idx);
+        }
+    }
+    // Fix: map each chunk's best_intent properly
+    for (chunk_idx, chunk) in chunks.iter().enumerate() {
+        intents[chunk.best_intent].matched_chunks.push(chunk_idx);
+    }
+    // Deduplicate matched_chunks
+    for intent in &mut intents {
+        intent.matched_chunks.sort_unstable();
+        intent.matched_chunks.dedup();
+    }
+
+    let partition_score = if chunks.is_empty() {
+        0.0
+    } else {
+        chunks.iter().map(|c| c.alignment_score).sum::<f64>() / chunks.len() as f64
+    };
+
+    Ok(IntentResult {
+        chunks,
+        intents,
+        partition_score,
+        block_count,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_centroid_basic() {
+        let embeddings = vec![vec![1.0, 0.0], vec![0.0, 1.0]];
+        let c = centroid(&embeddings, 0, 2);
+        assert!((c[0] - 0.5).abs() < f64::EPSILON);
+        assert!((c[1] - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_cosine_similarity_identical() {
+        let a = vec![1.0, 2.0, 3.0];
+        let sim = cosine_similarity(&a, &a);
+        assert!((sim - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cosine_similarity_orthogonal() {
+        let a = vec![1.0, 0.0];
+        let b = vec![0.0, 1.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!(sim.abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_estimate_tokens() {
+        assert_eq!(estimate_tokens("hello world foo bar"), 4);
+        assert_eq!(estimate_tokens(""), 0);
+    }
+}
+```
+
+- [ ] **Register in `src/semantic/mod.rs`**
+
+Add:
+
+```rust
+pub mod intent_chunk;
+```
+
+And add public re-exports at the bottom of the file (following the pattern of existing `cognitive_chunk` re-exports):
+
+```rust
+pub use intent_chunk::{intent_chunk, intent_chunk_plain};
+```
+
+- [ ] **Run `cargo check` and tests**
+
+Run: `cargo check 2>&1 | head -20`
+Run: `cargo test intent_chunk -- --nocapture 2>&1 | tail -20`
+Expected: compiles, 4 unit tests pass
+
+- [ ] **Commit**
+
+```bash
+git add src/semantic/intent_chunk.rs src/semantic/mod.rs
+git commit -m "feat(intent): add DP alignment pipeline"
+```
+
+### Step 2.4: Create CLI subcommand
+
+- [ ] **Create `src/cli/intent_cmd.rs`**
+
+This follows the exact pattern of `cognitive_cmd.rs`. The file should contain:
+- `IntentArgs` struct with clap derive (input, provider, model, api_key, base_url, model_path, cf_* OAuth flags, intent-model, max-intents, soft-budget, hard-budget, format, merge, chunk-size, no-markdown)
+- `pub async fn run(args: &IntentArgs, global: &GlobalOpts) -> anyhow::Result<()>` that:
+  1. Reads input via `read_input` (same helper as cognitive)
+  2. Resolves LLM config via `LlmConfig::resolve`
+  3. Creates `CompletionClient`
+  4. Constructs `IntentConfig`
+  5. Dispatches to provider (same match pattern as cognitive)
+  6. Calls `intent_chunk` or `intent_chunk_plain`
+  7. Optionally applies merge post-processing
+  8. Writes output in requested format
+
+The CLI args struct and run function are structurally identical to `cognitive_cmd.rs` but with fewer flags (no reranker, no relations, no synopsis, no emit-signals, no graph) and with `--intent-model` and `--max-intents` added.
+
+- [ ] **Register in `src/cli/mod.rs`**
+
+Add:
+
+```rust
+pub mod intent_cmd;
+```
+
+- [ ] **Register in `src/main.rs`**
+
+Add to Commands enum (after `Cognitive` variant):
+
+```rust
+    /// Intent-driven chunking optimized for predicted user queries
+    #[command(after_help = "\
+EXAMPLES:
+  cognigraph-chunker intent -i doc.md -p openai --api-key $KEY
+  cognigraph-chunker intent -i doc.md --intent-model gpt-4.1-mini --max-intents 30
+  cognigraph-chunker intent -i doc.md -p ollama -f json
+")]
+    Intent(Box<cli::intent_cmd::IntentArgs>),
+```
+
+Add match arm:
+
+```rust
+        Commands::Intent(args) => cli::intent_cmd::run(args, &cli.global).await,
+```
+
+- [ ] **Run `cargo check`**
+
+Run: `cargo check 2>&1 | head -20`
+Expected: compiles
+
+- [ ] **Commit**
+
+```bash
+git add src/cli/intent_cmd.rs src/cli/mod.rs src/main.rs
+git commit -m "feat(intent): add CLI subcommand"
+```
+
+### Step 2.5: Create API handler
+
+- [ ] **Create `src/api/intent.rs`**
+
+Follows the pattern of `src/api/cognitive.rs`. Defines:
+- `IntentRequest` (text, provider, model, api_key, base_url, model_path, cf_* OAuth flags, intent_model, max_intents, soft_budget, hard_budget, no_markdown)
+- `IntentResponse` (chunks, intents, partition_score, count)
+- `intent_handler` function matching the cognitive pattern (provider dispatch → `intent_chunk` / `intent_chunk_plain`)
+
+- [ ] **Register in `src/api/mod.rs`**
+
+Add `pub mod intent;` and route:
+
+```rust
+        .route(
+            "/api/v1/intent",
+            axum::routing::post(intent::intent_handler),
+        )
+```
+
+- [ ] **Run `cargo check`**
+
+Run: `cargo check 2>&1 | head -20`
+Expected: compiles
+
+- [ ] **Commit**
+
+```bash
+git add src/api/intent.rs src/api/mod.rs
+git commit -m "feat(intent): add POST /api/v1/intent endpoint"
+```
+
+---
+
+## Task 3: Enriched Chunking
+
+Structure-preserving chunking + single-call LLM enrichment with 7 metadata fields + semantic-key recombination.
+
+**Files:**
+- Create: `src/semantic/enriched_types.rs`
+- Create: `src/llm/enrichment.rs`
+- Create: `src/semantic/enriched_chunk.rs`
+- Create: `src/cli/enriched_cmd.rs`
+- Create: `src/api/enriched.rs`
+- Modify: `src/semantic/mod.rs`, `src/llm/mod.rs`, `src/cli/mod.rs`, `src/api/mod.rs`, `src/main.rs`
+
+### Step 3.1: Create enriched types
+
+- [ ] **Create `src/semantic/enriched_types.rs`**
+
+```rust
+//! Data types for enriched chunking.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// A typed entity extracted by the LLM.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TypedEntity {
+    pub name: String,
+    pub entity_type: String,
+}
+
+/// A record of chunks that were merged during key-based recombination.
+#[derive(Debug, Clone, Serialize)]
+pub struct MergeRecord {
+    pub result_chunk: usize,
+    pub source_chunks: Vec<usize>,
+    pub shared_key: String,
+}
+
+/// A single chunk produced by enriched chunking, with full metadata.
+#[derive(Debug, Clone, Serialize)]
+pub struct EnrichedChunk {
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+    pub token_estimate: usize,
+    pub title: String,
+    pub summary: String,
+    pub keywords: Vec<String>,
+    pub typed_entities: Vec<TypedEntity>,
+    pub hypothetical_questions: Vec<String>,
+    pub semantic_keys: Vec<String>,
+    pub category: String,
+    pub heading_path: Vec<String>,
+}
+
+/// Result of enriched chunking.
+#[derive(Debug)]
+pub struct EnrichedResult {
+    pub chunks: Vec<EnrichedChunk>,
+    /// Semantic key → list of chunk indices.
+    pub key_dictionary: HashMap<String, Vec<usize>>,
+    pub merge_history: Vec<MergeRecord>,
+    pub block_count: usize,
+}
+```
+
+- [ ] **Register in `src/semantic/mod.rs`**
+
+Add:
+
+```rust
+pub mod enriched_types;
+```
+
+- [ ] **Run `cargo check`, commit**
+
+```bash
+git add src/semantic/enriched_types.rs src/semantic/mod.rs
+git commit -m "feat(enriched): add enriched chunking data types"
+```
+
+### Step 3.2: Create LLM enrichment prompt
+
+- [ ] **Create `src/llm/enrichment.rs`**
+
+```rust
+//! Single-call LLM enrichment for enriched chunking.
+//!
+//! Extracts 7 metadata fields per chunk in one structured JSON call.
+//! Maintains a rolling semantic key dictionary across chunks.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use super::CompletionClient;
+use crate::semantic::enriched_types::TypedEntity;
+
+/// Raw enrichment response from the LLM.
+#[derive(Debug, Deserialize)]
+pub struct EnrichmentResponse {
+    pub title: String,
+    pub summary: String,
+    pub keywords: Vec<String>,
+    pub typed_entities: Vec<TypedEntity>,
+    pub hypothetical_questions: Vec<String>,
+    pub semantic_keys: Vec<String>,
+    pub category: String,
+}
+
+const SYSTEM_PROMPT: &str = "\
+You are a document enrichment engine. For each text chunk, extract structured metadata \
+to maximize its usefulness for information retrieval.
+
+Rules:
+- title: a descriptive title (5-15 words) capturing the chunk's main topic
+- summary: 1-2 sentence synopsis of the key content
+- keywords: 5-10 relevant terms or phrases (include domain-specific terminology)
+- typed_entities: named entities with types (person, organization, concept, location, etc.)
+- hypothetical_questions: 3-5 questions this chunk could answer (for search matching)
+- semantic_keys: 2-4 lowercase hyphenated topic keys (e.g. \"protein-folding\", \"clinical-dosing\")
+- category: one of: background, methodology, results, discussion, configuration, reference, definition, procedure, example, other
+
+For semantic_keys, reuse existing keys from the dictionary when the content matches. \
+Create new keys only for genuinely new topics.";
+
+fn json_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "title": { "type": "string" },
+            "summary": { "type": "string" },
+            "keywords": { "type": "array", "items": { "type": "string" } },
+            "typed_entities": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "entity_type": { "type": "string" }
+                    },
+                    "required": ["name", "entity_type"],
+                    "additionalProperties": false
+                }
+            },
+            "hypothetical_questions": { "type": "array", "items": { "type": "string" } },
+            "semantic_keys": { "type": "array", "items": { "type": "string" } },
+            "category": { "type": "string" }
+        },
+        "required": ["title", "summary", "keywords", "typed_entities", "hypothetical_questions", "semantic_keys", "category"],
+        "additionalProperties": false
+    })
+}
+
+/// Enrich a single chunk with 7 metadata fields.
+///
+/// The `existing_keys` parameter provides the rolling key dictionary
+/// so the LLM can reuse existing semantic keys.
+pub async fn enrich_chunk(
+    client: &CompletionClient,
+    text: &str,
+    existing_keys: &HashMap<String, Vec<usize>>,
+) -> Result<EnrichmentResponse> {
+    let key_list: String = if existing_keys.is_empty() {
+        "No existing keys yet.".to_string()
+    } else {
+        let keys: Vec<&str> = existing_keys.keys().map(|k| k.as_str()).collect();
+        format!("Existing semantic keys: {}", keys.join(", "))
+    };
+
+    let user_prompt = format!(
+        "{key_list}\n\nChunk text:\n{text}"
+    );
+
+    let response = client
+        .complete_json(SYSTEM_PROMPT, &user_prompt, json_schema())
+        .await
+        .context("Chunk enrichment failed")?;
+
+    serde_json::from_str(&response).context("Failed to parse enrichment response")
+}
+
+/// Re-enrich a merged chunk (title + summary only).
+pub async fn re_enrich_merged(
+    client: &CompletionClient,
+    text: &str,
+) -> Result<(String, String)> {
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "title": { "type": "string" },
+            "summary": { "type": "string" }
+        },
+        "required": ["title", "summary"],
+        "additionalProperties": false
+    });
+
+    let response = client
+        .complete_json(
+            "You are a summarization engine. Generate a title and 1-2 sentence summary for this merged chunk.",
+            text,
+            schema,
+        )
+        .await
+        .context("Re-enrichment failed")?;
+
+    #[derive(Deserialize)]
+    struct ReEnrich {
+        title: String,
+        summary: String,
+    }
+
+    let parsed: ReEnrich =
+        serde_json::from_str(&response).context("Failed to parse re-enrichment response")?;
+
+    Ok((parsed.title, parsed.summary))
+}
+```
+
+- [ ] **Register in `src/llm/mod.rs`**
+
+Add:
+
+```rust
+pub mod enrichment;
+```
+
+- [ ] **Run `cargo check`, commit**
+
+```bash
+git add src/llm/enrichment.rs src/llm/mod.rs
+git commit -m "feat(enriched): add LLM enrichment prompt with rolling keys"
+```
+
+### Step 3.3: Create enriched chunking pipeline
+
+- [ ] **Create `src/semantic/enriched_chunk.rs`**
+
+This file implements:
+- `EnrichedConfig` (soft_budget, hard_budget, recombine, re_enrich booleans)
+- `enriched_chunk()` — main pipeline: split_blocks → initial grouping → LLM enrichment → key-based recombination → optional re-enrichment
+- `enriched_chunk_plain()` — plain text variant
+- `initial_grouping()` — greedy accumulator respecting atomic blocks and heading starts
+- `recombine_by_keys()` — bin-packing merge of same-key chunks within hard budget
+
+Tests: `test_initial_grouping_respects_budget`, `test_initial_grouping_heading_starts_new_chunk`
+
+- [ ] **Register in `src/semantic/mod.rs`**
+
+Add `pub mod enriched_chunk;` and re-export `enriched_chunk::{enriched_chunk, enriched_chunk_plain}`.
+
+- [ ] **Run `cargo check` and tests, commit**
+
+```bash
+git add src/semantic/enriched_chunk.rs src/semantic/mod.rs
+git commit -m "feat(enriched): add enriched chunking pipeline with key recombination"
+```
+
+### Step 3.4: Create CLI subcommand and API handler
+
+- [ ] **Create `src/cli/enriched_cmd.rs`**
+
+Pattern: same as `intent_cmd.rs` but with:
+- No embedding provider flags (enriched doesn't need embeddings)
+- `--enrichment-model` instead of `--intent-model`
+- `--no-recombine`, `--no-re-enrich` boolean flags
+- Only needs LLM config (api-key, llm-base-url)
+
+- [ ] **Create `src/api/enriched.rs`**
+
+Pattern: same as `intent.rs` but without embedding provider dispatch — only needs `CompletionClient`.
+
+- [ ] **Register in `src/cli/mod.rs`, `src/api/mod.rs`, `src/main.rs`**
+
+Add module declarations, route, Commands variant + match arm.
+
+- [ ] **Run `cargo check`, commit**
+
+```bash
+git add src/cli/enriched_cmd.rs src/api/enriched.rs src/cli/mod.rs src/api/mod.rs src/main.rs
+git commit -m "feat(enriched): add CLI subcommand + API endpoint"
+```
+
+---
+
+## Task 4: Topology-Aware Chunking
+
+Builds a Structured Intermediate Representation (SIR) from the document, then uses two LLM agents (Inspector + Refiner) to produce topology-preserving chunks.
+
+**Files:**
+- Create: `src/semantic/sir.rs`
+- Create: `src/semantic/topo_types.rs`
+- Create: `src/llm/topo_agents.rs`
+- Create: `src/semantic/topo_chunk.rs`
+- Create: `src/cli/topo_cmd.rs`
+- Create: `src/api/topo.rs`
+- Modify: `src/semantic/mod.rs`, `src/llm/mod.rs`, `src/cli/mod.rs`, `src/api/mod.rs`, `src/main.rs`
+
+### Step 4.1: Create SIR data structures
+
+- [ ] **Create `src/semantic/sir.rs`**
+
+```rust
+//! Structured Intermediate Representation (SIR) for topology-aware chunking.
+//!
+//! The SIR is a tree built from the heading hierarchy with content blocks as leaves.
+//! Cross-reference edges link blocks that share entities or discourse continuations.
+
+use serde::{Deserialize, Serialize};
+
+use super::blocks::BlockKind;
+
+/// Type of node in the SIR tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SirNodeType {
+    /// A section defined by a heading.
+    Section,
+    /// A content block (sentence, table, code, list, etc.).
+    ContentBlock,
+}
+
+/// Type of cross-reference edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SirEdgeType {
+    /// Shared entity mentions between blocks.
+    EntityCoref,
+    /// Discourse continuation marker ("As described above").
+    DiscourseContinuation,
+}
+
+/// A node in the SIR tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SirNode {
+    pub id: usize,
+    pub node_type: SirNodeType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heading: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heading_level: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_type: Option<BlockKind>,
+    /// Start and end block indices (inclusive range).
+    pub block_range: (usize, usize),
+    pub children: Vec<usize>,
+    /// First 200 chars of text for LLM context.
+    pub text_preview: String,
+    pub token_estimate: usize,
+}
+
+/// A cross-reference edge between two SIR nodes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SirEdge {
+    pub from: usize,
+    pub to: usize,
+    pub edge_type: SirEdgeType,
+}
+
+/// The complete Structured Intermediate Representation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Sir {
+    pub nodes: Vec<SirNode>,
+    pub edges: Vec<SirEdge>,
+    pub root: usize,
+}
+```
+
+Note: `BlockKind` needs `Serialize, Deserialize` derives. The existing `BlockKind` in `src/semantic/blocks.rs` only has `Debug, Clone, Copy, PartialEq, Eq`. We need to add serde derives.
+
+- [ ] **Add serde derives to `BlockKind` in `src/semantic/blocks.rs`**
+
+Change line 14 from:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+```
+
+to:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+```
+
+- [ ] **Register in `src/semantic/mod.rs`**
+
+Add:
+
+```rust
+pub mod sir;
+```
+
+- [ ] **Run `cargo check`, commit**
+
+```bash
+git add src/semantic/sir.rs src/semantic/blocks.rs src/semantic/mod.rs
+git commit -m "feat(topo): add SIR data structures"
+```
+
+### Step 4.2: Create topo types
+
+- [ ] **Create `src/semantic/topo_types.rs`**
+
+```rust
+//! Data types for topology-aware chunking output.
+
+use serde::{Deserialize, Serialize};
+
+use super::sir::Sir;
+
+/// Section classification assigned by the Inspector agent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SectionClass {
+    Atomic,
+    Splittable,
+    MergeCandidate,
+}
+
+/// Classification of a section by the Inspector agent.
+#[derive(Debug, Clone, Serialize)]
+pub struct SectionClassification {
+    pub section_id: usize,
+    pub class: SectionClass,
+    pub reason: String,
+}
+
+/// A single chunk produced by topology-aware chunking.
+#[derive(Debug, Clone, Serialize)]
+pub struct TopoChunk {
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+    pub token_estimate: usize,
+    pub heading_path: Vec<String>,
+    pub section_classification: String,
+    /// Indices of other chunks this one depends on.
+    pub cross_references: Vec<usize>,
+}
+
+/// Result of topology-aware chunking.
+#[derive(Debug)]
+pub struct TopoResult {
+    pub chunks: Vec<TopoChunk>,
+    pub sir: Sir,
+    pub classifications: Vec<SectionClassification>,
+    pub block_count: usize,
+}
+```
+
+- [ ] **Register in `src/semantic/mod.rs`**, run `cargo check`, commit.
+
+```bash
+git add src/semantic/topo_types.rs src/semantic/mod.rs
+git commit -m "feat(topo): add topo chunking result types"
+```
+
+### Step 4.3: Create LLM topo agents
+
+- [ ] **Create `src/llm/topo_agents.rs`**
+
+Contains:
+- `InspectorResponse`, `RefinerResponse` deserialization types
+- `INSPECTOR_SYSTEM_PROMPT` — receives SIR JSON, classifies sections
+- `REFINER_SYSTEM_PROMPT` — receives Inspector output + SIR + text of splittable sections
+- `inspector_schema()`, `refiner_schema()` — JSON schemas
+- `pub async fn inspect_sir(client, sir_json) -> Result<InspectorResponse>`
+- `pub async fn refine_partition(client, inspector_output, sir_json, section_texts) -> Result<RefinerResponse>`
+- Context window handling: if SIR JSON > 80% of 128k tokens (~100k chars), truncate text_preview fields
+
+- [ ] **Register in `src/llm/mod.rs`**, run `cargo check`, commit.
+
+```bash
+git add src/llm/topo_agents.rs src/llm/mod.rs
+git commit -m "feat(topo): add Inspector + Refiner LLM agents"
+```
+
+### Step 4.4: Create topo chunking pipeline
+
+- [ ] **Create `src/semantic/topo_chunk.rs`**
+
+Implements:
+- `TopoConfig` (soft_budget, hard_budget, emit_sir boolean)
+- `topo_chunk(text, llm_client, config) -> Result<TopoResult>` — main pipeline
+- `build_sir(blocks, heading_paths, entities)` — heuristic SIR construction from blocks
+- `assemble_from_partition(blocks, partition, heading_paths)` — map LLM partition back to text spans
+
+Tests: `test_build_sir_basic`, `test_build_sir_flat_document`
+
+- [ ] **Register in `src/semantic/mod.rs`**, run tests, commit.
+
+### Step 4.5: Create CLI subcommand and API handler
+
+- [ ] **Create `src/cli/topo_cmd.rs`**
+
+Same pattern as enriched — no embedding provider, only LLM config. Adds `--topo-model`, `--emit-sir`.
+
+- [ ] **Create `src/api/topo.rs`**
+
+Same pattern as enriched API handler.
+
+- [ ] **Register everywhere, run `cargo check`, commit.**
+
+```bash
+git add src/cli/topo_cmd.rs src/api/topo.rs src/cli/mod.rs src/api/mod.rs src/main.rs
+git commit -m "feat(topo): add CLI subcommand + API endpoint"
+```
+
+---
+
+## Task 5: Adaptive Chunking
+
+Meta-router that scores candidates with quality metrics and picks the best.
+
+**Files:**
+- Create: `src/semantic/adaptive_types.rs`
+- Create: `src/semantic/adaptive_chunk.rs`
+- Create: `src/cli/adaptive_cmd.rs`
+- Create: `src/api/adaptive.rs`
+- Modify: `src/semantic/mod.rs`, `src/cli/mod.rs`, `src/api/mod.rs`, `src/main.rs`
+
+### Step 5.1: Create adaptive types
+
+- [ ] **Create `src/semantic/adaptive_types.rs`**
+
+```rust
+//! Data types for adaptive chunking.
+
+use serde::Serialize;
+
+use super::quality_metrics::{MetricWeights, QualityMetrics};
+
+/// Result of adaptive chunking.
+#[derive(Debug, Serialize)]
+pub struct AdaptiveResult {
+    /// Name of the winning method.
+    pub winner: String,
+    /// Chunks from the winning method (polymorphic JSON).
+    pub chunks: Vec<serde_json::Value>,
+    /// Quality evaluation report for all candidates.
+    pub report: AdaptiveReport,
+    /// Number of chunks in the winning result.
+    pub count: usize,
+}
+
+/// Full quality evaluation report.
+#[derive(Debug, Serialize)]
+pub struct AdaptiveReport {
+    pub candidates: Vec<CandidateScore>,
+    pub pre_screening: Vec<ScreeningDecision>,
+    pub metric_weights: MetricWeights,
+}
+
+/// Scores for a single candidate method.
+#[derive(Debug, Serialize)]
+pub struct CandidateScore {
+    pub method: String,
+    pub metrics: QualityMetrics,
+    pub chunk_count: usize,
+    pub total_tokens: usize,
+}
+
+/// Pre-screening decision for a candidate method.
+#[derive(Debug, Serialize)]
+pub struct ScreeningDecision {
+    pub method: String,
+    pub included: bool,
+    pub reason: String,
+}
+```
+
+- [ ] **Register in `src/semantic/mod.rs`**, run `cargo check`, commit.
+
+### Step 5.2: Create adaptive orchestrator
+
+- [ ] **Create `src/semantic/adaptive_chunk.rs`**
+
+Implements:
+- `AdaptiveConfig` (candidates list, force_candidates, metric_weights, soft/hard budget, provider configs)
+- `adaptive_chunk()` — main orchestrator:
+  1. Pre-screen candidates (heading level check for topo, token count for intent, structure check for enriched)
+  2. Run each candidate method
+  3. Convert each result to `Vec<ChunkForEval>` (generic text + offsets)
+  4. Score via `evaluate_chunks`
+  5. Pick winner by composite score (ties broken by fewer chunks)
+  6. Serialize winner's chunks as `Vec<serde_json::Value>`
+  7. Return `AdaptiveResult`
+
+Tests: `test_pre_screening_flat_doc`, `test_composite_score_selection`
+
+- [ ] **Register in `src/semantic/mod.rs`**, run tests, commit.
+
+### Step 5.3: Create CLI subcommand and API handler
+
+- [ ] **Create `src/cli/adaptive_cmd.rs`**
+
+Needs ALL provider flags (embedding + LLM) since it delegates to any method. Adds:
+- `--candidates <LIST>` (comma-separated)
+- `--force-candidates`
+- `--metric-weights <KEY=VALUE,...>`
+- `--report` (include quality report in JSON output)
+
+- [ ] **Create `src/api/adaptive.rs`**
+
+Accepts all provider credentials + `candidates`, `force_candidates`, `metric_weights`, `include_report`.
+
+- [ ] **Register everywhere, run `cargo check`, commit.**
+
+```bash
+git add src/semantic/adaptive_types.rs src/semantic/adaptive_chunk.rs src/cli/adaptive_cmd.rs src/api/adaptive.rs src/semantic/mod.rs src/cli/mod.rs src/api/mod.rs src/main.rs
+git commit -m "feat(adaptive): add meta-router with quality metrics scoring"
+```
+
+---
+
+## Task 6: Final Integration
+
+### Step 6.1: Run full test suite
+
+- [ ] **Run all tests**
+
+Run: `cargo test 2>&1 | tail -30`
+Expected: all existing 108 tests + new tests pass
+
+- [ ] **Run clippy**
+
+Run: `cargo clippy -- -W clippy::all 2>&1 | tail -20`
+Expected: no errors (warnings are acceptable)
+
+### Step 6.2: Verify all CLI subcommands are registered
+
+- [ ] **Check help output**
+
+Run: `cargo run -- --help 2>&1`
+Expected: `intent`, `topo`, `enriched`, `adaptive` appear in subcommand list alongside `chunk`, `split`, `semantic`, `cognitive`, `serve`
+
+### Step 6.3: Commit final integration
+
+```bash
+git add -A
+git commit -m "feat: integrate all 4 new chunking methods + quality metrics"
+```
+
+---
+
+## Task 7: Documentation
+
+### Step 7.1: Create doc articles
+
+- [ ] **Create `docs/10-intent-driven-chunking.md`** — describe the intent-driven method, pipeline, CLI flags, API endpoint, use cases (follows the style of existing `docs/07-cognition-aware-chunking.md`)
+
+- [ ] **Create `docs/11-topology-aware-chunking.md`** — describe the topo method, SIR construction, dual-agent architecture, CLI/API
+
+- [ ] **Create `docs/12-enriched-chunking.md`** — describe the enriched method, 7-field metadata, rolling keys, recombination, CLI/API
+
+- [ ] **Create `docs/13-adaptive-chunking.md`** — describe the adaptive method, 5 quality metrics, pre-screening, CLI/API
+
+- [ ] **Update `README.md`** — add new modes to the CLI reference table and method comparison
+
+- [ ] **Commit**
+
+```bash
+git add docs/10-intent-driven-chunking.md docs/11-topology-aware-chunking.md docs/12-enriched-chunking.md docs/13-adaptive-chunking.md README.md
+git commit -m "docs: add articles for 4 new chunking methods"
+```

--- a/docs/superpowers/specs/2026-04-10-new-chunking-methods-design.md
+++ b/docs/superpowers/specs/2026-04-10-new-chunking-methods-design.md
@@ -10,10 +10,10 @@ Four new chunking methods join the existing modes (`chunk`, `split`, `semantic`,
 
 | Method | CLI Command | Key Innovation | LLM Required | Embedding Required |
 |--------|-------------|----------------|--------------|-------------------|
-| Intent-Driven | `cognigraph intent` | Boundaries optimized for predicted user queries | Yes (intent generation) | Yes (alignment scoring) |
-| Topology-Aware | `cognigraph topo` | Hierarchical SIR + dual-agent refinement | Yes (2 agent calls) | No (structure-based) |
-| Enriched | `cognigraph enriched` | Single-call 7-field metadata + key-based recombination | Yes (enrichment) | No (structure + LLM) |
-| Adaptive | `cognigraph adaptive` | Meta-router: 5 quality metrics select best method per document | Depends on candidates | Yes (for metrics) |
+| Intent-Driven | `cognigraph-chunker intent` | Boundaries optimized for predicted user queries | Yes (intent generation) | Yes (alignment scoring) |
+| Topology-Aware | `cognigraph-chunker topo` | Hierarchical SIR + dual-agent refinement | Yes (2 agent calls) | No (structure-based) |
+| Enriched | `cognigraph-chunker enriched` | Single-call 7-field metadata + key-based recombination | Yes (enrichment) | No (structure + LLM) |
+| Adaptive | `cognigraph-chunker adaptive` | Meta-router: 5 quality metrics select best method per document | Depends on candidates | Yes (for metrics) |
 
 ### Architecture: Flat Peer Methods
 
@@ -124,7 +124,7 @@ pub struct PredictedIntent {
 ### CLI Interface
 
 ```
-cognigraph intent <FILE> [OPTIONS]
+cognigraph-chunker intent <FILE> [OPTIONS]
 
 Required:
   <FILE>                    Input file (or - for stdin)
@@ -336,7 +336,7 @@ pub struct SectionClassification {
 ### CLI Interface
 
 ```
-cognigraph topo <FILE> [OPTIONS]
+cognigraph-chunker topo <FILE> [OPTIONS]
 
 Required:
   <FILE>                    Input file (or - for stdin)
@@ -518,7 +518,7 @@ pub struct MergeRecord {
 ### CLI Interface
 
 ```
-cognigraph enriched <FILE> [OPTIONS]
+cognigraph-chunker enriched <FILE> [OPTIONS]
 
 Required:
   <FILE>                        Input file (or - for stdin)
@@ -743,7 +743,7 @@ pub struct ScreeningDecision {
 ### CLI Interface
 
 ```
-cognigraph adaptive <FILE> [OPTIONS]
+cognigraph-chunker adaptive <FILE> [OPTIONS]
 
 Required:
   <FILE>                        Input file (or - for stdin)

--- a/docs/superpowers/specs/2026-04-10-new-chunking-methods-design.md
+++ b/docs/superpowers/specs/2026-04-10-new-chunking-methods-design.md
@@ -1,0 +1,951 @@
+# New Chunking Methods Design
+
+**Date:** 2026-04-10
+**Status:** Draft
+**Scope:** 4 new first-class chunking methods + quality metrics module
+
+## Overview
+
+Four new chunking methods join the existing modes (`chunk`, `split`, `semantic`, `cognitive`) as peer-level CLI subcommands and API endpoints. Each method addresses a distinct gap identified in recent research (March 2026 preprints) and reuses shared infrastructure where possible.
+
+| Method | CLI Command | Key Innovation | LLM Required | Embedding Required |
+|--------|-------------|----------------|--------------|-------------------|
+| Intent-Driven | `cognigraph intent` | Boundaries optimized for predicted user queries | Yes (intent generation) | Yes (alignment scoring) |
+| Topology-Aware | `cognigraph topo` | Hierarchical SIR + dual-agent refinement | Yes (2 agent calls) | No (structure-based) |
+| Enriched | `cognigraph enriched` | Single-call 7-field metadata + key-based recombination | Yes (enrichment) | No (structure + LLM) |
+| Adaptive | `cognigraph adaptive` | Meta-router: 5 quality metrics select best method per document | Depends on candidates | Yes (for metrics) |
+
+### Architecture: Flat Peer Methods
+
+Each new method follows the exact pattern of existing modes:
+- CLI subcommand in `src/cli/{method}_cmd.rs` with clap args
+- API handler in `src/api/{method}.rs` with serde request/response
+- Core logic in `src/semantic/{method}_chunk.rs`
+- LLM prompts in `src/llm/{method}.rs` where applicable
+- Registered in `main.rs` Commands enum and `src/api/mod.rs` router
+
+No refactoring of existing methods is required.
+
+### Research References
+
+- **Intent-Driven Dynamic Chunking** (arXiv:2602.14784, Feb 2026) -- LLM intent prediction + DP boundary optimization
+- **TopoChunker** (arXiv:2603.18409, Mar 2026) -- topology-aware dual-agent framework with SIR
+- **MDKeyChunker** (arXiv:2603.23533, Mar 2026) -- single-call LLM enrichment + semantic-key recombination
+- **Adaptive Chunking** (arXiv:2603.25333, Mar 2026, LREC 2026) -- 5 intrinsic quality metrics + per-document method selection
+- **Systematic Chunking Study** (arXiv:2603.06976, Mar 2026) -- 36 strategies, 6 domains, paragraph grouping insights
+- **GraLC-RAG** (arXiv:2603.22633, Mar 2026) -- KG-infused late chunking for biomedical literature
+- **EntiGraph** (arXiv:2409.07431, ICLR 2025) -- entity-centric synthetic data augmentation
+
+---
+
+## Method 1: Intent-Driven Chunking (`intent`)
+
+### Purpose
+
+Optimize chunk boundaries for retrieval by aligning them with predicted user information needs. Instead of asking "where does the topic change?" this asks "what will users search for, and which partition best serves those searches?"
+
+### Pipeline
+
+```
+Document
+  |
+  v
+[1] Block extraction (reuse split_blocks / split_sentences)
+  |
+  v
+[2] Intent generation (single LLM call -> 10-30 hypothetical queries)
+  |
+  v
+[3] Block embedding (reuse EmbeddingProvider)
+  |
+  v
+[4] Intent embedding (same provider)
+  |
+  v
+[5] Alignment scoring (chunk centroid <-> best-matching intent)
+  |
+  v
+[6] Dynamic programming (globally optimal partition maximizing alignment)
+  |
+  v
+[7] IntentResult with chunks + intents + alignment scores
+```
+
+### Step Details
+
+**Step 2 -- Intent Generation:**
+- Uses `CompletionClient` with structured JSON output (`response_format: json_schema`)
+- Prompt sends document text (or summary for long docs exceeding context window)
+- Schema: `{ intents: [{ query: string, intent_type: "factual" | "procedural" | "conceptual" | "comparative" }] }`
+- Default: 20 intents, configurable via `--max-intents`
+- Model: configurable via `--intent-model` (default: `gpt-4.1-mini`)
+
+**Step 5 -- Alignment Scoring:**
+- For a candidate chunk (contiguous block range), compute centroid embedding (mean of block embeddings)
+- Score = max cosine similarity between chunk centroid and any intent embedding
+- Total partition score = sum of per-chunk alignment scores, normalized by chunk count
+
+**Step 6 -- Dynamic Programming:**
+- State: `dp[i]` = best total alignment score for blocks `0..i`
+- Transition: for each valid chunk ending at block `i`, try all start positions `j` where `(i-j)` is within `[min_blocks, max_blocks]`
+- `min_blocks` derived from `soft_budget / avg_block_tokens`
+- `max_blocks` derived from `hard_budget / avg_block_tokens`
+- Time complexity: O(n * max_blocks) where n = number of blocks
+- Backtrack to recover the optimal partition
+
+### Data Structures
+
+```rust
+// src/semantic/intent_types.rs
+
+pub struct IntentResult {
+    pub chunks: Vec<IntentChunk>,
+    pub intents: Vec<PredictedIntent>,
+    pub partition_score: f64,
+}
+
+pub struct IntentChunk {
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+    pub token_estimate: usize,
+    pub best_intent: usize,          // index into intents vec
+    pub alignment_score: f64,
+    pub heading_path: Vec<String>,
+}
+
+pub struct PredictedIntent {
+    pub query: String,
+    pub intent_type: IntentType,     // Factual, Procedural, Conceptual, Comparative
+    pub matched_chunks: Vec<usize>,  // chunk indices that align with this intent
+}
+```
+
+### CLI Interface
+
+```
+cognigraph intent <FILE> [OPTIONS]
+
+Required:
+  <FILE>                    Input file (or - for stdin)
+
+Embedding provider (same flags as semantic/cognitive):
+  --provider <PROVIDER>     ollama|openai|onnx|cloudflare|oauth
+  --model <MODEL>           Embedding model name
+  --base-url <URL>          Provider base URL
+
+LLM configuration:
+  --intent-model <MODEL>    Model for intent generation [default: gpt-4.1-mini]
+  --api-key <KEY>           API key for LLM (or OPENAI_API_KEY env)
+  --llm-base-url <URL>      LLM endpoint [default: https://api.openai.com/v1]
+
+Method parameters:
+  --max-intents <N>         Maximum intents to generate [default: 20]
+  --soft-budget <N>         Target tokens per chunk [default: 512]
+  --hard-budget <N>         Maximum tokens per chunk [default: 768]
+
+Output:
+  --format <FMT>            plain|json|jsonl [default: plain]
+  --merge                   Post-merge small chunks
+  --chunk-size <N>          Merge target size [default: 512]
+```
+
+### API Endpoint
+
+```
+POST /api/v1/intent
+
+Request:
+{
+  "text": "...",
+  "provider": "openai",
+  "model": "text-embedding-3-small",
+  "intent_model": "gpt-4.1-mini",
+  "max_intents": 20,
+  "soft_budget": 512,
+  "hard_budget": 768
+}
+
+Response:
+{
+  "chunks": [ { "text": "...", "offset_start": 0, "offset_end": 1234, "token_estimate": 450, "best_intent": 2, "alignment_score": 0.87, "heading_path": ["Introduction"] } ],
+  "intents": [ { "query": "What are the side effects of compound XR-7742?", "intent_type": "factual", "matched_chunks": [3, 7] } ],
+  "partition_score": 0.82,
+  "count": 12
+}
+```
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/semantic/intent_chunk.rs` | DP algorithm, alignment scoring, pipeline orchestration |
+| `src/semantic/intent_types.rs` | IntentResult, IntentChunk, PredictedIntent structs |
+| `src/llm/intents.rs` | Intent generation prompt + JSON schema |
+| `src/cli/intent_cmd.rs` | CLI subcommand definition + run function |
+| `src/api/intent.rs` | API handler |
+
+### Reused Components
+
+- `src/semantic/blocks.rs` -- `split_blocks()` for markdown block extraction
+- `src/semantic/sentence.rs` -- `split_sentences()` for plain text
+- `src/embeddings/*` -- all 5 embedding providers
+- `src/llm/mod.rs` -- `CompletionClient` for structured LLM calls
+- `src/core/merge.rs` -- optional post-merge
+
+---
+
+## Method 2: Topology-Aware Chunking (`topo`)
+
+### Purpose
+
+Preserve hierarchical document structure during chunking by building an explicit Structured Intermediate Representation (SIR) before making boundary decisions. Two LLM agents inspect and refine the structure, producing chunks that maintain cross-section dependencies.
+
+### Pipeline
+
+```
+Document
+  |
+  v
+[1] Block extraction (reuse split_blocks)
+  |
+  v
+[2] Heuristic SIR construction (heading tree + entity co-reference edges)
+  |
+  v
+[3] Inspector Agent (LLM call #1: classify sections, detect cross-references)
+  |
+  v
+[4] Refiner Agent (LLM call #2: resolve ambiguities, produce final partition)
+  |
+  v
+[5] Assembly (map node groups back to text spans)
+  |
+  v
+[6] TopoResult with chunks + SIR + classifications
+```
+
+### Step Details
+
+**Step 2 -- SIR Construction:**
+
+The SIR is a tree built from the heading hierarchy with content blocks as leaves:
+
+```
+Document (root)
+  |-- Section "Introduction" (h1)
+  |     |-- Paragraph block 1
+  |     |-- Paragraph block 2
+  |-- Section "Methods" (h1)
+  |     |-- Section "Data Collection" (h2)
+  |     |     |-- Paragraph block 3
+  |     |     |-- Table block 4
+  |     |-- Section "Analysis" (h2)
+  |           |-- Paragraph block 5
+  |           |-- Code block 6
+  |-- Section "Results" (h1)
+        |-- Paragraph block 7
+        |-- Table block 8
+```
+
+Additionally, cross-reference edges are added:
+- Entity co-reference: if blocks 3 and 7 both mention "Compound XR-7742", an edge links them
+- Discourse continuation: if block 5 starts with "As described above," it gets an edge to the preceding section
+
+This construction reuses our existing `heading_context.rs` for the tree and `entities.rs` + `discourse.rs` for edges.
+
+**Context Window Handling:**
+- If the SIR JSON exceeds 80% of the model's context window, large content blocks are summarized (first/last 100 chars + token count) to fit
+- Cross-reference edges are preserved even when block text is truncated
+- The Refiner receives full text only for sections classified as `splittable` (not the entire document)
+
+**Step 3 -- Inspector Agent:**
+- Receives the SIR as a JSON tree (section titles, block types, block lengths -- not full text to keep prompt short)
+- Classifies each section node as:
+  - `atomic` -- must stay together as one chunk (e.g., a short definition section)
+  - `splittable` -- can be divided at block boundaries
+  - `merge_candidate` -- should be merged with an adjacent section (e.g., a tiny section with only one paragraph)
+- Identifies cross-section dependencies: pairs of sections that reference each other
+- Schema: `{ classifications: [{ section_id, class, reason }], dependencies: [{ from, to, type }] }`
+
+**Step 4 -- Refiner Agent:**
+- Receives Inspector's output + the SIR + full text of ambiguous sections only
+- For `splittable` sections: determines optimal split points within the section
+- For `merge_candidate` pairs: decides direction of merge
+- For cross-section dependencies: ensures dependent content stays in the same chunk or has explicit cross-references in output
+- Outputs: `{ partition: [{ chunk_id, section_ids, block_ranges }] }`
+
+**Step 5 -- Assembly:**
+- Map the Refiner's partition back to byte ranges in the original document
+- Each chunk carries its heading ancestry, the Inspector's classification, and any cross-chunk references
+
+### Data Structures
+
+```rust
+// src/semantic/sir.rs
+
+pub struct SirNode {
+    pub id: usize,
+    pub node_type: SirNodeType,        // Section, ContentBlock
+    pub heading: Option<String>,
+    pub heading_level: Option<u8>,
+    pub block_type: Option<BlockType>,  // Sentence, Table, Code, etc.
+    pub block_range: (usize, usize),   // start/end block indices
+    pub children: Vec<usize>,          // child node IDs
+    pub text_preview: String,          // first 200 chars for LLM context
+    pub token_estimate: usize,
+}
+
+pub struct SirEdge {
+    pub from: usize,
+    pub to: usize,
+    pub edge_type: SirEdgeType,        // EntityCoref, DiscourseContinuation, HeadingNesting
+}
+
+pub struct Sir {
+    pub nodes: Vec<SirNode>,
+    pub edges: Vec<SirEdge>,
+    pub root: usize,
+}
+
+// src/semantic/topo_types.rs
+
+pub struct TopoResult {
+    pub chunks: Vec<TopoChunk>,
+    pub sir: Sir,
+    pub classifications: Vec<SectionClassification>,
+}
+
+pub struct TopoChunk {
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+    pub token_estimate: usize,
+    pub heading_path: Vec<String>,
+    pub section_classification: String,  // atomic|splittable|merged
+    pub cross_references: Vec<usize>,    // other chunk indices this depends on
+}
+
+pub struct SectionClassification {
+    pub section_id: usize,
+    pub class: SectionClass,           // Atomic, Splittable, MergeCandidate
+    pub reason: String,
+}
+```
+
+### CLI Interface
+
+```
+cognigraph topo <FILE> [OPTIONS]
+
+Required:
+  <FILE>                    Input file (or - for stdin)
+
+LLM configuration:
+  --topo-model <MODEL>      Model for both agents [default: gpt-4.1-mini]
+  --api-key <KEY>           API key for LLM
+  --llm-base-url <URL>      LLM endpoint [default: https://api.openai.com/v1]
+
+Method parameters:
+  --soft-budget <N>         Target tokens per chunk [default: 512]
+  --hard-budget <N>         Maximum tokens per chunk [default: 768]
+
+Output:
+  --format <FMT>            plain|json|jsonl [default: plain]
+  --emit-sir                Include SIR structure in JSON output
+```
+
+### API Endpoint
+
+```
+POST /api/v1/topo
+
+Request:
+{
+  "text": "...",
+  "topo_model": "gpt-4.1-mini",
+  "soft_budget": 512,
+  "hard_budget": 768,
+  "emit_sir": false
+}
+
+Response:
+{
+  "chunks": [ { "text": "...", "offset_start": 0, "offset_end": 2048, "token_estimate": 480, "heading_path": ["Methods", "Data Collection"], "section_classification": "atomic", "cross_references": [4] } ],
+  "count": 8
+}
+```
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/semantic/sir.rs` | SIR data structures (SirNode, SirEdge, Sir) |
+| `src/semantic/topo_chunk.rs` | SIR builder, assembly, pipeline orchestration |
+| `src/semantic/topo_types.rs` | TopoResult, TopoChunk structs |
+| `src/llm/topo_agents.rs` | Inspector + Refiner prompts and JSON schemas |
+| `src/cli/topo_cmd.rs` | CLI subcommand |
+| `src/api/topo.rs` | API handler |
+
+### Reused Components
+
+- `src/semantic/blocks.rs` -- `split_blocks()` and `BlockType` enum
+- `src/semantic/enrichment/heading_context.rs` -- heading hierarchy
+- `src/semantic/enrichment/entities.rs` -- entity detection for co-reference edges
+- `src/semantic/enrichment/discourse.rs` -- discourse markers for continuation edges
+- `src/llm/mod.rs` -- `CompletionClient`
+
+---
+
+## Method 3: Enriched Chunking (`enriched`)
+
+### Purpose
+
+Structure-preserving chunking combined with rich LLM-generated metadata per chunk, followed by semantic-key-based recombination. Produces chunks that are self-describing and retrieval-optimized without requiring embeddings.
+
+### Pipeline
+
+```
+Document
+  |
+  v
+[1] Block extraction (reuse split_blocks)
+  |
+  v
+[2] Initial grouping (size-based, soft budget target)
+  |
+  v
+[3] Single-call LLM enrichment per chunk (7 metadata fields, rolling key dict)
+  |
+  v
+[4] Key-based recombination (bin-packing on shared semantic keys)
+  |
+  v
+[5] Optional re-enrichment (update title/summary for merged chunks)
+  |
+  v
+[6] EnrichedResult with chunks + metadata + key dictionary
+```
+
+### Step Details
+
+**Step 2 -- Initial Grouping:**
+- Simple greedy accumulation: add blocks to current chunk until soft budget is reached
+- Respect atomic blocks (tables, code blocks, lists stay whole)
+- Heading blocks start a new chunk (same as semantic mode)
+- No embeddings needed -- purely structural
+
+**Step 3 -- Single-Call LLM Enrichment:**
+
+Each chunk gets one LLM call that extracts all 7 fields simultaneously:
+
+```json
+{
+  "title": "Compound XR-7742 Dosing Protocol",
+  "summary": "Describes the three-phase dosing schedule for XR-7742 in adult patients, including titration windows and contraindications.",
+  "keywords": ["XR-7742", "dosing", "titration", "contraindications", "phase I"],
+  "typed_entities": [
+    {"name": "XR-7742", "type": "compound"},
+    {"name": "Phase I", "type": "study_phase"},
+    {"name": "FDA", "type": "organization"}
+  ],
+  "hypothetical_questions": [
+    "What is the recommended starting dose for XR-7742?",
+    "What are the contraindications for XR-7742?",
+    "How long is the titration window for XR-7742?"
+  ],
+  "semantic_keys": ["xr-7742-dosing", "clinical-protocol"],
+  "category": "methodology"
+}
+```
+
+**Rolling Key Dictionary:**
+- Maintained across chunks during sequential processing
+- Each enrichment call receives the current dictionary as context
+- LLM can reuse existing keys (creating shared-key links) or create new ones
+- Dictionary: `HashMap<String, Vec<usize>>` -- key name to list of chunk indices
+
+**Step 4 -- Key-Based Recombination:**
+- Identify chunks sharing identical semantic keys
+- For each group of same-key chunks, attempt bin-packing merge subject to hard budget
+- Priority: merge chunks that are both same-key AND adjacent in document order
+- Non-adjacent same-key chunks: merge only if combined size fits within hard budget
+- Chunks with unique keys (no sharing) remain untouched
+
+**Step 5 -- Re-Enrichment:**
+- Only runs for chunks that were actually merged (content changed)
+- Lightweight call: update `title` and `summary` only (not all 7 fields)
+- Preserves original keywords, entities, questions, keys from constituent chunks (union)
+
+### Data Structures
+
+```rust
+// src/semantic/enriched_types.rs
+
+pub struct EnrichedResult {
+    pub chunks: Vec<EnrichedChunk>,
+    pub key_dictionary: HashMap<String, Vec<usize>>,
+    pub merge_history: Vec<MergeRecord>,
+}
+
+pub struct EnrichedChunk {
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+    pub token_estimate: usize,
+    pub title: String,
+    pub summary: String,
+    pub keywords: Vec<String>,
+    pub typed_entities: Vec<TypedEntity>,
+    pub hypothetical_questions: Vec<String>,
+    pub semantic_keys: Vec<String>,
+    pub category: String,
+    pub heading_path: Vec<String>,
+}
+
+pub struct TypedEntity {
+    pub name: String,
+    pub entity_type: String,
+}
+
+pub struct MergeRecord {
+    pub result_chunk: usize,
+    pub source_chunks: Vec<usize>,
+    pub shared_key: String,
+}
+```
+
+### CLI Interface
+
+```
+cognigraph enriched <FILE> [OPTIONS]
+
+Required:
+  <FILE>                        Input file (or - for stdin)
+
+LLM configuration:
+  --enrichment-model <MODEL>    Model for enrichment [default: gpt-4.1-mini]
+  --api-key <KEY>               API key for LLM
+  --llm-base-url <URL>          LLM endpoint [default: https://api.openai.com/v1]
+
+Method parameters:
+  --soft-budget <N>             Target tokens per chunk [default: 512]
+  --hard-budget <N>             Maximum tokens per chunk [default: 768]
+  --no-recombine                Skip key-based recombination step
+  --no-re-enrich                Skip re-enrichment of merged chunks
+
+Output:
+  --format <FMT>                plain|json|jsonl [default: plain]
+```
+
+### API Endpoint
+
+```
+POST /api/v1/enriched
+
+Request:
+{
+  "text": "...",
+  "enrichment_model": "gpt-4.1-mini",
+  "soft_budget": 512,
+  "hard_budget": 768,
+  "recombine": true,
+  "re_enrich": true
+}
+
+Response:
+{
+  "chunks": [ { "text": "...", "title": "...", "summary": "...", "keywords": [...], "typed_entities": [...], "hypothetical_questions": [...], "semantic_keys": [...], "category": "...", "heading_path": [...] } ],
+  "key_dictionary": { "xr-7742-dosing": [0, 3], "clinical-protocol": [0, 1, 3] },
+  "count": 10
+}
+```
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/semantic/enriched_chunk.rs` | Pipeline orchestration, initial grouping, key-based recombination |
+| `src/semantic/enriched_types.rs` | EnrichedResult, EnrichedChunk, TypedEntity structs |
+| `src/llm/enrichment.rs` | 7-field enrichment prompt, JSON schema, rolling key logic |
+| `src/cli/enriched_cmd.rs` | CLI subcommand |
+| `src/api/enriched.rs` | API handler |
+
+### Reused Components
+
+- `src/semantic/blocks.rs` -- `split_blocks()` and block types
+- `src/semantic/enrichment/heading_context.rs` -- heading path for chunks
+- `src/llm/mod.rs` -- `CompletionClient`
+- No embedding provider needed
+
+---
+
+## Method 4: Adaptive Chunking (`adaptive`)
+
+### Purpose
+
+Meta-router that automatically selects the best chunking method for each document by evaluating 5 intrinsic quality metrics on the output of candidate methods. No single chunking strategy works best for all documents -- adaptive routing closes this gap.
+
+### Pipeline
+
+```
+Document
+  |
+  v
+[1] Pre-screening (heuristic: which candidates are worth trying?)
+  |
+  v
+[2] Run candidate methods (parallel where possible)
+  |
+  v
+[3] Score each candidate's output (5 intrinsic quality metrics)
+  |
+  v
+[4] Select winner (highest composite score)
+  |
+  v
+[5] AdaptiveResult = winner's output + quality report
+```
+
+### Step Details
+
+**Step 1 -- Pre-Screening:**
+
+Lightweight heuristics to skip expensive methods on unsuitable documents:
+
+| Method | Skip If |
+|--------|---------|
+| `topo` | Document has < 2 heading levels (flat structure, nothing to topology-ize) |
+| `intent` | Document < 500 tokens (too short for meaningful intent generation) |
+| `enriched` | Document has no markdown structure AND < 1000 tokens (too simple to benefit from enrichment overhead) |
+| `cognitive` | (always run -- it's the general-purpose heavyweight) |
+| `semantic` | (always run -- it's the general-purpose baseline) |
+
+Pre-screening is advisory: `--force-candidates` overrides it.
+
+**Step 2 -- Running Candidates:**
+- Default candidates: `semantic`, `cognitive`, `intent`, `enriched`, `topo`
+- User can restrict: `--candidates semantic,cognitive,intent`
+- Methods are run sequentially (LLM-dependent ones can't easily parallelize due to shared API key rate limits)
+- Results cached in memory -- if adaptive is called after a manual cognitive run in the same API session, the cached result is reused
+
+**Step 3 -- Quality Metrics:**
+
+Five intrinsic metrics, each scored 0.0 to 1.0:
+
+**Size Compliance (SC):**
+```
+SC = count(chunks where soft_budget * 0.5 <= tokens <= hard_budget) / total_chunks
+```
+Measures whether chunks are appropriately sized. Too small = fragmented, too large = monolithic.
+
+**Intrachunk Cohesion (ICC):**
+```
+For each chunk:
+  1. Split into sentences
+  2. Embed each sentence + embed full chunk text
+  3. Compute mean cosine similarity of sentence embeddings to chunk embedding
+ICC = mean of per-chunk cohesion scores
+```
+Requires embedding provider. Measures whether each chunk is about one thing.
+
+**Contextual Coherence (DCC):**
+```
+For each adjacent chunk pair (i, i+1):
+  1. Embed both chunk texts
+  2. Compute cosine similarity
+DCC = mean of adjacent-pair similarities
+```
+Higher = smoother transitions. Very high values may indicate under-splitting.
+
+**Block Integrity (BI):**
+```
+BI = count(structural_elements_fully_contained) / total_structural_elements
+```
+Structural elements = tables, code blocks, lists, block quotes. Checks that none are split across chunk boundaries. Uses byte offset tracking from block extraction.
+
+**Reference Completeness (RC):**
+```
+For each chunk boundary:
+  1. Check if next chunk starts with pronoun/demonstrative without antecedent in same chunk
+  2. Check if entities introduced in prev chunk are referenced in next chunk (entity orphan)
+RC = 1.0 - (orphan_count / total_boundary_count)
+```
+Maps directly to our existing orphan risk and entity continuity signals from cognitive mode.
+
+**Composite Score:**
+```
+composite = w_sc * SC + w_icc * ICC + w_dcc * DCC + w_bi * BI + w_rc * RC
+```
+Default weights: equal (0.20 each). Configurable via `--metric-weights sc=0.15,icc=0.25,dcc=0.20,bi=0.20,rc=0.20`.
+
+**Step 4 -- Winner Selection:**
+- Method with highest composite score wins
+- Ties broken by: fewer chunks (prefer less fragmentation)
+- Output includes full quality report for all candidates
+
+### Data Structures
+
+```rust
+// src/semantic/quality_metrics.rs
+
+pub struct QualityMetrics {
+    pub size_compliance: f64,
+    pub intrachunk_cohesion: f64,
+    pub contextual_coherence: f64,
+    pub block_integrity: f64,
+    pub reference_completeness: f64,
+    pub composite: f64,
+}
+
+pub struct MetricWeights {
+    pub sc: f64,
+    pub icc: f64,
+    pub dcc: f64,
+    pub bi: f64,
+    pub rc: f64,
+}
+
+impl Default for MetricWeights {
+    fn default() -> Self {
+        Self { sc: 0.20, icc: 0.20, dcc: 0.20, bi: 0.20, rc: 0.20 }
+    }
+}
+
+// src/semantic/adaptive_types.rs
+
+pub struct AdaptiveResult {
+    pub winner: String,                          // method name
+    pub chunks: Vec<serde_json::Value>,          // winner's chunk output (polymorphic -- each method has different metadata, so we use Value for the unified response)
+    pub report: AdaptiveReport,
+}
+
+pub struct AdaptiveReport {
+    pub candidates: Vec<CandidateScore>,
+    pub pre_screening: Vec<ScreeningDecision>,
+    pub metric_weights: MetricWeights,
+}
+
+pub struct CandidateScore {
+    pub method: String,
+    pub metrics: QualityMetrics,
+    pub chunk_count: usize,
+    pub total_tokens: usize,
+}
+
+pub struct ScreeningDecision {
+    pub method: String,
+    pub included: bool,
+    pub reason: String,
+}
+```
+
+### CLI Interface
+
+```
+cognigraph adaptive <FILE> [OPTIONS]
+
+Required:
+  <FILE>                        Input file (or - for stdin)
+
+Embedding provider (needed for ICC/DCC metrics + embedding-based candidates):
+  --provider <PROVIDER>         ollama|openai|onnx|cloudflare|oauth
+  --model <MODEL>               Embedding model name
+  --base-url <URL>              Provider base URL
+
+LLM configuration (needed for LLM-based candidates):
+  --api-key <KEY>               API key for LLM
+  --llm-base-url <URL>          LLM endpoint [default: https://api.openai.com/v1]
+  --llm-model <MODEL>           Model for LLM-based methods [default: gpt-4.1-mini]
+
+Method parameters:
+  --candidates <LIST>           Comma-separated method names [default: semantic,cognitive,intent,enriched,topo]
+  --force-candidates            Bypass pre-screening heuristics
+  --metric-weights <WEIGHTS>    Metric weights as key=value pairs [default: equal]
+  --soft-budget <N>             Target tokens per chunk [default: 512]
+  --hard-budget <N>             Maximum tokens per chunk [default: 768]
+
+Output:
+  --format <FMT>                plain|json|jsonl [default: plain]
+  --report                      Include quality report in output (JSON only)
+```
+
+### API Endpoint
+
+```
+POST /api/v1/adaptive
+
+Request:
+{
+  "text": "...",
+  "provider": "openai",
+  "model": "text-embedding-3-small",
+  "api_key": "...",
+  "candidates": ["semantic", "cognitive", "intent", "enriched"],
+  "soft_budget": 512,
+  "hard_budget": 768,
+  "metric_weights": { "sc": 0.15, "icc": 0.25, "dcc": 0.20, "bi": 0.20, "rc": 0.20 },
+  "include_report": true
+}
+
+Response:
+{
+  "winner": "cognitive",
+  "chunks": [ ... ],
+  "count": 12,
+  "report": {
+    "candidates": [
+      { "method": "semantic", "metrics": { "size_compliance": 0.85, "intrachunk_cohesion": 0.72, "contextual_coherence": 0.68, "block_integrity": 0.90, "reference_completeness": 0.65, "composite": 0.76 }, "chunk_count": 15, "total_tokens": 6200 },
+      { "method": "cognitive", "metrics": { "size_compliance": 0.92, "intrachunk_cohesion": 0.78, "contextual_coherence": 0.71, "block_integrity": 0.95, "reference_completeness": 0.88, "composite": 0.85 }, "chunk_count": 12, "total_tokens": 5800 }
+    ],
+    "pre_screening": [
+      { "method": "topo", "included": false, "reason": "Document has < 2 heading levels" }
+    ]
+  }
+}
+```
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/semantic/quality_metrics.rs` | 5 metric implementations (standalone, reusable for benchmarking) |
+| `src/semantic/adaptive_chunk.rs` | Orchestrator: pre-screening, candidate dispatch, scoring, selection |
+| `src/semantic/adaptive_types.rs` | AdaptiveResult, AdaptiveReport, CandidateScore structs |
+| `src/cli/adaptive_cmd.rs` | CLI subcommand |
+| `src/api/adaptive.rs` | API handler |
+
+### Reused Components
+
+- All existing chunking methods as callable functions
+- `src/embeddings/*` -- for ICC and DCC metric computation
+- `src/semantic/enrichment/entities.rs` -- for RC metric
+- `src/semantic/blocks.rs` -- for BI metric (block type tracking)
+- `src/semantic/enrichment/heading_context.rs` -- for orphan detection in RC
+
+---
+
+## Quality Metrics Module (Standalone)
+
+The 5 quality metrics are implemented as a standalone module (`src/semantic/quality_metrics.rs`) that can evaluate ANY chunking output, not just adaptive candidates. This enables:
+
+- **Benchmarking:** compare chunking methods on a corpus
+- **CI integration:** assert minimum quality scores in tests
+- **API endpoint:** `POST /api/v1/evaluate` accepts pre-chunked output and returns metrics
+
+```rust
+// Standalone evaluation function
+pub async fn evaluate_chunks<P: EmbeddingProvider>(
+    original_text: &str,
+    chunks: &[ChunkForEval],
+    provider: &P,
+    config: &MetricConfig,
+) -> Result<QualityMetrics>
+
+pub struct ChunkForEval {
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+}
+
+pub struct MetricConfig {
+    pub soft_budget: usize,
+    pub hard_budget: usize,
+    pub weights: MetricWeights,
+}
+```
+
+---
+
+## Shared Infrastructure Summary
+
+| Component | Used By |
+|-----------|---------|
+| `split_blocks()` | intent, topo, enriched, adaptive (via candidates) |
+| `EmbeddingProvider` trait | intent, adaptive (metrics) |
+| `CompletionClient` | intent, topo, enriched |
+| `heading_context.rs` | topo (SIR), enriched (heading paths) |
+| `entities.rs` | topo (co-reference edges), adaptive (RC metric) |
+| `discourse.rs` | topo (continuation edges) |
+| `merge_splits()` | intent (optional post-merge), enriched (recombination) |
+| Block type tracking | adaptive (BI metric), enriched (atomic blocks) |
+
+---
+
+## Registration Changes
+
+### main.rs -- Commands Enum
+
+Add 4 variants:
+```rust
+Intent(Box<cli::intent_cmd::IntentArgs>),
+Topo(Box<cli::topo_cmd::TopoArgs>),
+Enriched(Box<cli::enriched_cmd::EnrichedArgs>),
+Adaptive(Box<cli::adaptive_cmd::AdaptiveArgs>),
+```
+
+### main.rs -- Match Arms
+
+```rust
+Commands::Intent(args) => cli::intent_cmd::run(args, &cli.global).await,
+Commands::Topo(args) => cli::topo_cmd::run(args, &cli.global).await,
+Commands::Enriched(args) => cli::enriched_cmd::run(args, &cli.global).await,
+Commands::Adaptive(args) => cli::adaptive_cmd::run(args, &cli.global).await,
+```
+
+### src/api/mod.rs -- Router
+
+```rust
+.route("/api/v1/intent", axum::routing::post(intent::intent_handler))
+.route("/api/v1/topo", axum::routing::post(topo::topo_handler))
+.route("/api/v1/enriched", axum::routing::post(enriched::enriched_handler))
+.route("/api/v1/adaptive", axum::routing::post(adaptive::adaptive_handler))
+.route("/api/v1/evaluate", axum::routing::post(evaluate::evaluate_handler))
+```
+
+### lib.rs -- Module Declarations
+
+No new top-level modules needed. New files go under existing `semantic`, `llm`, `cli`, `api` modules.
+
+---
+
+## Testing Strategy
+
+Each method gets:
+
+1. **Unit tests** in its core module (pipeline logic, scoring, assembly)
+2. **Integration test** with a sample markdown file (end-to-end through CLI)
+3. **Quality metric validation** -- assert metrics are computed correctly on known inputs
+
+Adaptive gets additional tests:
+- Pre-screening logic (flat doc skips topo, short doc skips intent)
+- Winner selection with known metric values
+- Composite score computation with custom weights
+
+Estimated new tests: ~40-50 across all methods.
+
+---
+
+## Documentation
+
+Each method gets a doc article in `docs/`:
+- `10-intent-driven-chunking.md`
+- `11-topology-aware-chunking.md`
+- `12-enriched-chunking.md`
+- `13-adaptive-chunking.md`
+
+Plus update `README.md` with the new modes in the CLI reference table.
+
+---
+
+## Implementation Order
+
+Recommended sequence based on dependency graph:
+
+1. **Quality Metrics module** -- needed by Adaptive, useful for validating other methods
+2. **Intent-Driven** -- independent, reuses embeddings + LLM
+3. **Enriched** -- independent, reuses blocks + LLM
+4. **Topology-Aware** -- independent, reuses enrichment + LLM
+5. **Adaptive** -- depends on all other methods being available as candidates
+6. **Documentation** -- articles + README update
+7. **Benchmarks** -- run quality metrics across methods on sample corpus

--- a/packages/python/Cargo.toml
+++ b/packages/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognigraph-python"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [lib]
@@ -11,5 +11,6 @@ crate-type = ["cdylib"]
 cognigraph-chunker = { path = "../.." }
 pyo3 = { version = "0.28", features = ["extension-module"] }
 numpy = "0.28"
-tokio = { version = "1.49", features = ["rt-multi-thread"] }
+tokio = { version = "1.51", features = ["rt-multi-thread"] }
 anyhow = "1.0"
+serde_json = "1.0"

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cognigraph-chunker"
-version = "0.1.0"
+version = "0.2.0"
 requires-python = ">=3.9"
 
 [tool.maturin]

--- a/packages/python/src/adaptive.rs
+++ b/packages/python/src/adaptive.rs
@@ -1,0 +1,280 @@
+//! Python bindings for adaptive chunking.
+
+use pyo3::prelude::*;
+
+use cognigraph_chunker::embeddings::EmbeddingProvider;
+use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
+use cognigraph_chunker::semantic::adaptive_chunk::{
+    AdaptiveConfig as RustAdaptiveConfig, adaptive_chunk,
+};
+use cognigraph_chunker::semantic::adaptive_types::{
+    AdaptiveReport, AdaptiveResult, CandidateScore, ScreeningDecision,
+};
+use cognigraph_chunker::semantic::quality_metrics::MetricWeights;
+
+use crate::error::to_py_err;
+use crate::quality_metrics::{PyMetricWeights, PyQualityMetrics};
+use crate::semantic::RUNTIME;
+use crate::semantic::providers::{PyOllamaProvider, PyOnnxProvider, PyOpenAiProvider};
+
+// ── AdaptiveConfig ────────────────────────────────────────────────────────────
+
+#[pyclass(name = "AdaptiveConfig", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyAdaptiveConfig {
+    #[pyo3(get, set)]
+    pub candidates: Vec<String>,
+    #[pyo3(get, set)]
+    pub force_candidates: bool,
+    #[pyo3(get, set)]
+    pub soft_budget: usize,
+    #[pyo3(get, set)]
+    pub hard_budget: usize,
+    #[pyo3(get, set)]
+    pub metric_weights: Option<PyMetricWeights>,
+    #[pyo3(get, set)]
+    pub sim_window: usize,
+    #[pyo3(get, set)]
+    pub sg_window: usize,
+    #[pyo3(get, set)]
+    pub poly_order: usize,
+}
+
+#[pymethods]
+impl PyAdaptiveConfig {
+    #[new]
+    #[pyo3(signature = (
+        *,
+        candidates=None,
+        force_candidates=false,
+        soft_budget=512,
+        hard_budget=768,
+        metric_weights=None,
+        sim_window=3,
+        sg_window=11,
+        poly_order=3,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        candidates: Option<Vec<String>>,
+        force_candidates: bool,
+        soft_budget: usize,
+        hard_budget: usize,
+        metric_weights: Option<PyMetricWeights>,
+        sim_window: usize,
+        sg_window: usize,
+        poly_order: usize,
+    ) -> Self {
+        Self {
+            candidates: candidates
+                .unwrap_or_else(|| vec!["semantic".to_string(), "cognitive".to_string()]),
+            force_candidates,
+            soft_budget,
+            hard_budget,
+            metric_weights,
+            sim_window,
+            sg_window,
+            poly_order,
+        }
+    }
+}
+
+impl From<&PyAdaptiveConfig> for RustAdaptiveConfig {
+    fn from(py: &PyAdaptiveConfig) -> Self {
+        let metric_weights = py
+            .metric_weights
+            .as_ref()
+            .map(MetricWeights::from)
+            .unwrap_or_default();
+        Self {
+            candidates: py.candidates.clone(),
+            force_candidates: py.force_candidates,
+            soft_budget: py.soft_budget,
+            hard_budget: py.hard_budget,
+            metric_weights,
+            sim_window: py.sim_window,
+            sg_window: py.sg_window,
+            poly_order: py.poly_order,
+        }
+    }
+}
+
+// ── CandidateScore ────────────────────────────────────────────────────────────
+
+#[pyclass(name = "CandidateScore", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyCandidateScore {
+    #[pyo3(get)]
+    pub method: String,
+    #[pyo3(get)]
+    pub metrics: PyQualityMetrics,
+    #[pyo3(get)]
+    pub chunk_count: usize,
+    #[pyo3(get)]
+    pub total_tokens: usize,
+}
+
+impl From<CandidateScore> for PyCandidateScore {
+    fn from(r: CandidateScore) -> Self {
+        Self {
+            method: r.method,
+            metrics: PyQualityMetrics::from(r.metrics),
+            chunk_count: r.chunk_count,
+            total_tokens: r.total_tokens,
+        }
+    }
+}
+
+// ── ScreeningDecision ─────────────────────────────────────────────────────────
+
+#[pyclass(name = "ScreeningDecision", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyScreeningDecision {
+    #[pyo3(get)]
+    pub method: String,
+    #[pyo3(get)]
+    pub included: bool,
+    #[pyo3(get)]
+    pub reason: String,
+}
+
+impl From<ScreeningDecision> for PyScreeningDecision {
+    fn from(r: ScreeningDecision) -> Self {
+        Self {
+            method: r.method,
+            included: r.included,
+            reason: r.reason,
+        }
+    }
+}
+
+// ── AdaptiveReport ────────────────────────────────────────────────────────────
+
+#[pyclass(name = "AdaptiveReport", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyAdaptiveReport {
+    #[pyo3(get)]
+    pub candidates: Vec<PyCandidateScore>,
+    #[pyo3(get)]
+    pub pre_screening: Vec<PyScreeningDecision>,
+    #[pyo3(get)]
+    pub metric_weights: PyMetricWeights,
+}
+
+impl From<AdaptiveReport> for PyAdaptiveReport {
+    fn from(r: AdaptiveReport) -> Self {
+        Self {
+            candidates: r
+                .candidates
+                .into_iter()
+                .map(PyCandidateScore::from)
+                .collect(),
+            pre_screening: r
+                .pre_screening
+                .into_iter()
+                .map(PyScreeningDecision::from)
+                .collect(),
+            metric_weights: PyMetricWeights::from(r.metric_weights),
+        }
+    }
+}
+
+// ── AdaptiveResult ────────────────────────────────────────────────────────────
+
+#[pyclass(name = "AdaptiveResult")]
+pub struct PyAdaptiveResult {
+    #[pyo3(get)]
+    pub winner: String,
+    /// The winner's chunks serialized as a JSON string.
+    #[pyo3(get)]
+    pub chunks_json: String,
+    #[pyo3(get)]
+    pub report: PyAdaptiveReport,
+    #[pyo3(get)]
+    pub count: usize,
+}
+
+impl From<AdaptiveResult> for PyAdaptiveResult {
+    fn from(r: AdaptiveResult) -> Self {
+        let chunks_json = serde_json::to_string(&r.chunks).unwrap_or_else(|_| "[]".to_string());
+        Self {
+            winner: r.winner,
+            chunks_json,
+            report: PyAdaptiveReport::from(r.report),
+            count: r.count,
+        }
+    }
+}
+
+// ── py_adaptive_chunk ─────────────────────────────────────────────────────────
+
+/// Run adaptive chunking, selecting the best method from the configured candidates.
+#[pyfunction]
+#[pyo3(signature = (text, provider, api_key=None, base_url=None, model=None, config=None))]
+pub fn py_adaptive_chunk(
+    py: Python<'_>,
+    text: &str,
+    provider: &Bound<'_, PyAny>,
+    api_key: Option<String>,
+    base_url: Option<String>,
+    model: Option<String>,
+    config: Option<&PyAdaptiveConfig>,
+) -> PyResult<PyAdaptiveResult> {
+    let rust_config = config.map(RustAdaptiveConfig::from).unwrap_or_default();
+    let text_owned = text.to_string();
+
+    // Build optional LLM client
+    let llm_client: Option<CompletionClient> = if api_key.is_some() {
+        let llm_config = LlmConfig::resolve(&api_key, &base_url, &model).map_err(to_py_err)?;
+        Some(CompletionClient::new(llm_config).map_err(to_py_err)?)
+    } else {
+        None
+    };
+
+    let _ = py;
+
+    if let Ok(p) = provider.cast::<PyOllamaProvider>() {
+        let provider_ref = p.borrow();
+        return run_adaptive(
+            &text_owned,
+            &provider_ref.inner,
+            llm_client.as_ref(),
+            &rust_config,
+        );
+    }
+    if let Ok(p) = provider.cast::<PyOpenAiProvider>() {
+        let provider_ref = p.borrow();
+        return run_adaptive(
+            &text_owned,
+            &provider_ref.inner,
+            llm_client.as_ref(),
+            &rust_config,
+        );
+    }
+    if let Ok(p) = provider.cast::<PyOnnxProvider>() {
+        let provider_ref = p.borrow();
+        return run_adaptive(
+            &text_owned,
+            &provider_ref.inner,
+            llm_client.as_ref(),
+            &rust_config,
+        );
+    }
+
+    Err(pyo3::exceptions::PyTypeError::new_err(
+        "provider must be OllamaProvider, OpenAiProvider, or OnnxProvider",
+    ))
+}
+
+fn run_adaptive<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: Option<&CompletionClient>,
+    config: &RustAdaptiveConfig,
+) -> PyResult<PyAdaptiveResult> {
+    let result = RUNTIME
+        .block_on(async { adaptive_chunk(text, provider, llm_client, config).await })
+        .map_err(to_py_err)?;
+
+    Ok(PyAdaptiveResult::from(result))
+}

--- a/packages/python/src/enriched.rs
+++ b/packages/python/src/enriched.rs
@@ -1,0 +1,204 @@
+//! Python bindings for enriched chunking.
+
+use std::collections::HashMap;
+
+use pyo3::prelude::*;
+
+use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
+use cognigraph_chunker::semantic::enriched_chunk::{
+    EnrichedConfig as RustEnrichedConfig, enriched_chunk, enriched_chunk_plain,
+};
+use cognigraph_chunker::semantic::enriched_types::{
+    EnrichedChunk, EnrichedResult, MergeRecord, TypedEntity,
+};
+
+use crate::error::to_py_err;
+use crate::semantic::RUNTIME;
+
+/// Configuration for the enriched chunking pipeline.
+#[pyclass(name = "EnrichedConfig", from_py_object)]
+#[derive(Clone)]
+pub struct PyEnrichedConfig {
+    #[pyo3(get, set)]
+    pub soft_budget: usize,
+    #[pyo3(get, set)]
+    pub hard_budget: usize,
+    #[pyo3(get, set)]
+    pub recombine: bool,
+    #[pyo3(get, set)]
+    pub re_enrich: bool,
+}
+
+#[pymethods]
+impl PyEnrichedConfig {
+    #[new]
+    #[pyo3(signature = (*, soft_budget=512, hard_budget=768, recombine=true, re_enrich=true))]
+    fn new(soft_budget: usize, hard_budget: usize, recombine: bool, re_enrich: bool) -> Self {
+        Self {
+            soft_budget,
+            hard_budget,
+            recombine,
+            re_enrich,
+        }
+    }
+}
+
+impl From<&PyEnrichedConfig> for RustEnrichedConfig {
+    fn from(py: &PyEnrichedConfig) -> Self {
+        Self {
+            soft_budget: py.soft_budget,
+            hard_budget: py.hard_budget,
+            recombine: py.recombine,
+            re_enrich: py.re_enrich,
+        }
+    }
+}
+
+/// A typed entity (name + type label).
+#[pyclass(name = "TypedEntity", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyTypedEntity {
+    #[pyo3(get)]
+    pub name: String,
+    #[pyo3(get)]
+    pub entity_type: String,
+}
+
+/// A record of a merge operation during semantic-key recombination.
+#[pyclass(name = "MergeRecord", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyMergeRecord {
+    #[pyo3(get)]
+    pub result_chunk: usize,
+    #[pyo3(get)]
+    pub source_chunks: Vec<usize>,
+    #[pyo3(get)]
+    pub shared_key: String,
+}
+
+/// A single enriched chunk with full LLM-generated metadata.
+#[pyclass(name = "EnrichedChunk", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyEnrichedChunk {
+    #[pyo3(get)]
+    pub text: String,
+    #[pyo3(get)]
+    pub offset_start: usize,
+    #[pyo3(get)]
+    pub offset_end: usize,
+    #[pyo3(get)]
+    pub token_estimate: usize,
+    #[pyo3(get)]
+    pub title: String,
+    #[pyo3(get)]
+    pub summary: String,
+    #[pyo3(get)]
+    pub keywords: Vec<String>,
+    #[pyo3(get)]
+    pub typed_entities: Vec<PyTypedEntity>,
+    #[pyo3(get)]
+    pub hypothetical_questions: Vec<String>,
+    #[pyo3(get)]
+    pub semantic_keys: Vec<String>,
+    #[pyo3(get)]
+    pub category: String,
+    #[pyo3(get)]
+    pub heading_path: Vec<String>,
+}
+
+/// Result of the enriched chunking pipeline.
+#[pyclass(name = "EnrichedResult")]
+pub struct PyEnrichedResult {
+    #[pyo3(get)]
+    pub chunks: Vec<PyEnrichedChunk>,
+    #[pyo3(get)]
+    pub key_dictionary: HashMap<String, Vec<usize>>,
+    #[pyo3(get)]
+    pub merge_history: Vec<PyMergeRecord>,
+    #[pyo3(get)]
+    pub block_count: usize,
+}
+
+fn convert_result(result: EnrichedResult) -> PyEnrichedResult {
+    let chunks = result
+        .chunks
+        .into_iter()
+        .map(|c: EnrichedChunk| PyEnrichedChunk {
+            text: c.text,
+            offset_start: c.offset_start,
+            offset_end: c.offset_end,
+            token_estimate: c.token_estimate,
+            title: c.title,
+            summary: c.summary,
+            keywords: c.keywords,
+            typed_entities: c
+                .typed_entities
+                .into_iter()
+                .map(|e: TypedEntity| PyTypedEntity {
+                    name: e.name,
+                    entity_type: e.entity_type,
+                })
+                .collect(),
+            hypothetical_questions: c.hypothetical_questions,
+            semantic_keys: c.semantic_keys,
+            category: c.category,
+            heading_path: c.heading_path,
+        })
+        .collect();
+
+    let merge_history = result
+        .merge_history
+        .into_iter()
+        .map(|m: MergeRecord| PyMergeRecord {
+            result_chunk: m.result_chunk,
+            source_chunks: m.source_chunks,
+            shared_key: m.shared_key,
+        })
+        .collect();
+
+    PyEnrichedResult {
+        chunks,
+        key_dictionary: result.key_dictionary,
+        merge_history,
+        block_count: result.block_count,
+    }
+}
+
+/// Run enriched chunking using an LLM (no embedding provider required).
+///
+/// Args:
+///     text: Input text to chunk.
+///     api_key: OpenAI-compatible API key.
+///     base_url: Optional API base URL (defaults to https://api.openai.com/v1).
+///     model: Optional model name (defaults to gpt-4.1-mini).
+///     config: Optional EnrichedConfig instance.
+///     markdown: If True (default), parse input as markdown; otherwise plain text.
+#[pyfunction]
+#[pyo3(signature = (text, api_key, base_url=None, model=None, config=None, *, markdown=true))]
+pub fn py_enriched_chunk(
+    _py: Python<'_>,
+    text: &str,
+    api_key: String,
+    base_url: Option<String>,
+    model: Option<String>,
+    config: Option<&PyEnrichedConfig>,
+    markdown: bool,
+) -> PyResult<PyEnrichedResult> {
+    let rust_config = config.map(RustEnrichedConfig::from).unwrap_or_default();
+    let text_owned = text.to_string();
+
+    let llm_config = LlmConfig::resolve(&Some(api_key), &base_url, &model).map_err(to_py_err)?;
+    let llm_client = CompletionClient::new(llm_config).map_err(to_py_err)?;
+
+    let result = RUNTIME
+        .block_on(async {
+            if markdown {
+                enriched_chunk(&text_owned, &llm_client, &rust_config).await
+            } else {
+                enriched_chunk_plain(&text_owned, &llm_client, &rust_config).await
+            }
+        })
+        .map_err(to_py_err)?;
+
+    Ok(convert_result(result))
+}

--- a/packages/python/src/intent.rs
+++ b/packages/python/src/intent.rs
@@ -1,0 +1,209 @@
+//! Python bindings for intent-driven chunking.
+
+use pyo3::prelude::*;
+
+use cognigraph_chunker::embeddings::EmbeddingProvider;
+use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
+use cognigraph_chunker::semantic::intent_chunk::{
+    IntentConfig as RustIntentConfig, intent_chunk, intent_chunk_plain,
+};
+use cognigraph_chunker::semantic::intent_types::IntentType;
+
+use crate::error::to_py_err;
+use crate::semantic::RUNTIME;
+use crate::semantic::providers::{PyOllamaProvider, PyOnnxProvider, PyOpenAiProvider};
+
+/// Configuration for intent-driven chunking.
+#[pyclass(name = "IntentConfig", from_py_object)]
+#[derive(Clone)]
+pub struct PyIntentConfig {
+    #[pyo3(get, set)]
+    pub max_intents: usize,
+    #[pyo3(get, set)]
+    pub soft_budget: usize,
+    #[pyo3(get, set)]
+    pub hard_budget: usize,
+}
+
+#[pymethods]
+impl PyIntentConfig {
+    #[new]
+    #[pyo3(signature = (*, max_intents=20, soft_budget=512, hard_budget=768))]
+    fn new(max_intents: usize, soft_budget: usize, hard_budget: usize) -> Self {
+        Self {
+            max_intents,
+            soft_budget,
+            hard_budget,
+        }
+    }
+}
+
+impl From<&PyIntentConfig> for RustIntentConfig {
+    fn from(py: &PyIntentConfig) -> Self {
+        Self {
+            max_intents: py.max_intents,
+            soft_budget: py.soft_budget,
+            hard_budget: py.hard_budget,
+        }
+    }
+}
+
+/// A predicted user intent with matched chunk indices.
+#[pyclass(name = "PredictedIntent", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyPredictedIntent {
+    #[pyo3(get)]
+    pub query: String,
+    #[pyo3(get)]
+    pub intent_type: String,
+    #[pyo3(get)]
+    pub matched_chunks: Vec<usize>,
+}
+
+/// A chunk produced by intent-driven chunking.
+#[pyclass(name = "IntentChunk", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyIntentChunk {
+    #[pyo3(get)]
+    pub text: String,
+    #[pyo3(get)]
+    pub offset_start: usize,
+    #[pyo3(get)]
+    pub offset_end: usize,
+    #[pyo3(get)]
+    pub token_estimate: usize,
+    #[pyo3(get)]
+    pub best_intent: usize,
+    #[pyo3(get)]
+    pub alignment_score: f64,
+    #[pyo3(get)]
+    pub heading_path: Vec<String>,
+}
+
+/// Result of intent-driven chunking.
+#[pyclass(name = "IntentResult")]
+pub struct PyIntentResult {
+    #[pyo3(get)]
+    pub chunks: Vec<PyIntentChunk>,
+    #[pyo3(get)]
+    pub intents: Vec<PyPredictedIntent>,
+    #[pyo3(get)]
+    pub partition_score: f64,
+    #[pyo3(get)]
+    pub block_count: usize,
+}
+
+/// Run intent-driven chunking with a provider.
+#[pyfunction]
+#[pyo3(signature = (text, provider, api_key, base_url=None, model=None, config=None, *, markdown=true))]
+#[allow(clippy::too_many_arguments)]
+pub fn py_intent_chunk(
+    py: Python<'_>,
+    text: &str,
+    provider: &Bound<'_, PyAny>,
+    api_key: String,
+    base_url: Option<String>,
+    model: Option<String>,
+    config: Option<&PyIntentConfig>,
+    markdown: bool,
+) -> PyResult<PyIntentResult> {
+    let rust_config = config.map(RustIntentConfig::from).unwrap_or_default();
+    let text_owned = text.to_string();
+
+    let llm_config = LlmConfig::resolve(&Some(api_key), &base_url, &model).map_err(to_py_err)?;
+    let llm_client = CompletionClient::new(llm_config).map_err(to_py_err)?;
+
+    let _ = py;
+    if let Ok(p) = provider.cast::<PyOllamaProvider>() {
+        let provider_ref = p.borrow();
+        return run_intent(
+            &text_owned,
+            &provider_ref.inner,
+            &llm_client,
+            &rust_config,
+            markdown,
+        );
+    }
+    if let Ok(p) = provider.cast::<PyOpenAiProvider>() {
+        let provider_ref = p.borrow();
+        return run_intent(
+            &text_owned,
+            &provider_ref.inner,
+            &llm_client,
+            &rust_config,
+            markdown,
+        );
+    }
+    if let Ok(p) = provider.cast::<PyOnnxProvider>() {
+        let provider_ref = p.borrow();
+        return run_intent(
+            &text_owned,
+            &provider_ref.inner,
+            &llm_client,
+            &rust_config,
+            markdown,
+        );
+    }
+
+    Err(pyo3::exceptions::PyTypeError::new_err(
+        "provider must be OllamaProvider, OpenAiProvider, or OnnxProvider",
+    ))
+}
+
+fn run_intent<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: &CompletionClient,
+    config: &RustIntentConfig,
+    markdown: bool,
+) -> PyResult<PyIntentResult> {
+    let result = RUNTIME
+        .block_on(async {
+            if markdown {
+                intent_chunk(text, provider, llm_client, config).await
+            } else {
+                intent_chunk_plain(text, provider, llm_client, config).await
+            }
+        })
+        .map_err(to_py_err)?;
+
+    let chunks = result
+        .chunks
+        .into_iter()
+        .map(|c| PyIntentChunk {
+            text: c.text,
+            offset_start: c.offset_start,
+            offset_end: c.offset_end,
+            token_estimate: c.token_estimate,
+            best_intent: c.best_intent,
+            alignment_score: c.alignment_score,
+            heading_path: c.heading_path,
+        })
+        .collect();
+
+    let intents = result
+        .intents
+        .into_iter()
+        .map(|i| PyPredictedIntent {
+            query: i.query,
+            intent_type: intent_type_to_str(i.intent_type).to_string(),
+            matched_chunks: i.matched_chunks,
+        })
+        .collect();
+
+    Ok(PyIntentResult {
+        chunks,
+        intents,
+        partition_score: result.partition_score,
+        block_count: result.block_count,
+    })
+}
+
+fn intent_type_to_str(t: IntentType) -> &'static str {
+    match t {
+        IntentType::Factual => "factual",
+        IntentType::Procedural => "procedural",
+        IntentType::Conceptual => "conceptual",
+        IntentType::Comparative => "comparative",
+    }
+}

--- a/packages/python/src/lib.rs
+++ b/packages/python/src/lib.rs
@@ -1,10 +1,15 @@
+mod adaptive;
 mod chunker;
 mod cognitive;
+mod enriched;
 mod error;
+mod intent;
 mod merge;
+mod quality_metrics;
 mod semantic;
 mod signal;
 mod splitter;
+mod topo;
 
 use pyo3::prelude::*;
 
@@ -51,7 +56,45 @@ fn cognigraph_chunker(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<cognitive::PyCognitiveConfig>()?;
     m.add_class::<cognitive::PyCognitiveResult>()?;
     m.add_class::<cognitive::PyCognitiveChunk>()?;
+    m.add_class::<cognitive::PyRelationTriple>()?;
     m.add_function(wrap_pyfunction!(cognitive::py_cognitive_chunk, m)?)?;
+
+    // Intent-driven chunking
+    m.add_class::<intent::PyIntentConfig>()?;
+    m.add_class::<intent::PyIntentResult>()?;
+    m.add_class::<intent::PyIntentChunk>()?;
+    m.add_class::<intent::PyPredictedIntent>()?;
+    m.add_function(wrap_pyfunction!(intent::py_intent_chunk, m)?)?;
+
+    // Enriched chunking
+    m.add_class::<enriched::PyEnrichedConfig>()?;
+    m.add_class::<enriched::PyEnrichedResult>()?;
+    m.add_class::<enriched::PyEnrichedChunk>()?;
+    m.add_class::<enriched::PyTypedEntity>()?;
+    m.add_class::<enriched::PyMergeRecord>()?;
+    m.add_function(wrap_pyfunction!(enriched::py_enriched_chunk, m)?)?;
+
+    // Topology-aware chunking
+    m.add_class::<topo::PyTopoConfig>()?;
+    m.add_class::<topo::PyTopoResult>()?;
+    m.add_class::<topo::PyTopoChunk>()?;
+    m.add_class::<topo::PySectionClassification>()?;
+    m.add_function(wrap_pyfunction!(topo::py_topo_chunk, m)?)?;
+
+    // Quality metrics
+    m.add_class::<quality_metrics::PyMetricWeights>()?;
+    m.add_class::<quality_metrics::PyQualityMetrics>()?;
+    m.add_class::<quality_metrics::PyChunkForEval>()?;
+    m.add_class::<quality_metrics::PyMetricConfig>()?;
+    m.add_function(wrap_pyfunction!(quality_metrics::py_evaluate_chunks, m)?)?;
+
+    // Adaptive chunking
+    m.add_class::<adaptive::PyAdaptiveConfig>()?;
+    m.add_class::<adaptive::PyAdaptiveResult>()?;
+    m.add_class::<adaptive::PyAdaptiveReport>()?;
+    m.add_class::<adaptive::PyCandidateScore>()?;
+    m.add_class::<adaptive::PyScreeningDecision>()?;
+    m.add_function(wrap_pyfunction!(adaptive::py_adaptive_chunk, m)?)?;
 
     Ok(())
 }

--- a/packages/python/src/quality_metrics.rs
+++ b/packages/python/src/quality_metrics.rs
@@ -1,0 +1,223 @@
+//! Python bindings for quality metrics evaluation.
+
+use pyo3::prelude::*;
+
+use cognigraph_chunker::embeddings::EmbeddingProvider;
+use cognigraph_chunker::semantic::quality_metrics::{
+    ChunkForEval, MetricConfig, MetricWeights, QualityMetrics, evaluate_chunks,
+};
+
+use crate::error::to_py_err;
+use crate::semantic::RUNTIME;
+use crate::semantic::providers::{PyOllamaProvider, PyOnnxProvider, PyOpenAiProvider};
+
+// ── PyMetricWeights ───────────────────────────────────────────────────────────
+
+#[pyclass(name = "MetricWeights", from_py_object)]
+#[derive(Clone)]
+pub struct PyMetricWeights {
+    #[pyo3(get, set)]
+    pub sc: f64,
+    #[pyo3(get, set)]
+    pub icc: f64,
+    #[pyo3(get, set)]
+    pub dcc: f64,
+    #[pyo3(get, set)]
+    pub bi: f64,
+    #[pyo3(get, set)]
+    pub rc: f64,
+}
+
+#[pymethods]
+impl PyMetricWeights {
+    #[new]
+    #[pyo3(signature = (*, sc=0.20, icc=0.20, dcc=0.20, bi=0.20, rc=0.20))]
+    fn new(sc: f64, icc: f64, dcc: f64, bi: f64, rc: f64) -> Self {
+        Self {
+            sc,
+            icc,
+            dcc,
+            bi,
+            rc,
+        }
+    }
+}
+
+impl From<&PyMetricWeights> for MetricWeights {
+    fn from(py: &PyMetricWeights) -> Self {
+        Self {
+            sc: py.sc,
+            icc: py.icc,
+            dcc: py.dcc,
+            bi: py.bi,
+            rc: py.rc,
+        }
+    }
+}
+
+impl From<MetricWeights> for PyMetricWeights {
+    fn from(m: MetricWeights) -> Self {
+        Self {
+            sc: m.sc,
+            icc: m.icc,
+            dcc: m.dcc,
+            bi: m.bi,
+            rc: m.rc,
+        }
+    }
+}
+
+// ── PyQualityMetrics ──────────────────────────────────────────────────────────
+
+#[pyclass(name = "QualityMetrics", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyQualityMetrics {
+    #[pyo3(get)]
+    pub size_compliance: f64,
+    #[pyo3(get)]
+    pub intrachunk_cohesion: f64,
+    #[pyo3(get)]
+    pub contextual_coherence: f64,
+    #[pyo3(get)]
+    pub block_integrity: f64,
+    #[pyo3(get)]
+    pub reference_completeness: f64,
+    #[pyo3(get)]
+    pub composite: f64,
+}
+
+impl From<QualityMetrics> for PyQualityMetrics {
+    fn from(m: QualityMetrics) -> Self {
+        Self {
+            size_compliance: m.size_compliance,
+            intrachunk_cohesion: m.intrachunk_cohesion,
+            contextual_coherence: m.contextual_coherence,
+            block_integrity: m.block_integrity,
+            reference_completeness: m.reference_completeness,
+            composite: m.composite,
+        }
+    }
+}
+
+// ── PyChunkForEval ────────────────────────────────────────────────────────────
+
+#[pyclass(name = "ChunkForEval", from_py_object)]
+#[derive(Clone)]
+pub struct PyChunkForEval {
+    #[pyo3(get, set)]
+    pub text: String,
+    #[pyo3(get, set)]
+    pub offset_start: usize,
+    #[pyo3(get, set)]
+    pub offset_end: usize,
+}
+
+#[pymethods]
+impl PyChunkForEval {
+    #[new]
+    fn new(text: String, offset_start: usize, offset_end: usize) -> Self {
+        Self {
+            text,
+            offset_start,
+            offset_end,
+        }
+    }
+}
+
+impl From<&PyChunkForEval> for ChunkForEval {
+    fn from(py: &PyChunkForEval) -> Self {
+        Self {
+            text: py.text.clone(),
+            offset_start: py.offset_start,
+            offset_end: py.offset_end,
+        }
+    }
+}
+
+// ── PyMetricConfig ────────────────────────────────────────────────────────────
+
+#[pyclass(name = "MetricConfig", from_py_object)]
+#[derive(Clone)]
+pub struct PyMetricConfig {
+    #[pyo3(get, set)]
+    pub soft_budget: usize,
+    #[pyo3(get, set)]
+    pub hard_budget: usize,
+    #[pyo3(get, set)]
+    pub weights: Option<PyMetricWeights>,
+}
+
+#[pymethods]
+impl PyMetricConfig {
+    #[new]
+    #[pyo3(signature = (*, soft_budget=512, hard_budget=768, weights=None))]
+    fn new(soft_budget: usize, hard_budget: usize, weights: Option<PyMetricWeights>) -> Self {
+        Self {
+            soft_budget,
+            hard_budget,
+            weights,
+        }
+    }
+}
+
+impl From<&PyMetricConfig> for MetricConfig {
+    fn from(py: &PyMetricConfig) -> Self {
+        Self {
+            soft_budget: py.soft_budget,
+            hard_budget: py.hard_budget,
+            weights: py
+                .weights
+                .as_ref()
+                .map(MetricWeights::from)
+                .unwrap_or_default(),
+        }
+    }
+}
+
+// ── py_evaluate_chunks ────────────────────────────────────────────────────────
+
+/// Evaluate quality metrics for a set of chunks against the original text.
+#[pyfunction]
+#[pyo3(signature = (original_text, chunks, provider, config=None))]
+pub fn py_evaluate_chunks(
+    py: Python<'_>,
+    original_text: &str,
+    chunks: Vec<PyChunkForEval>,
+    provider: &Bound<'_, PyAny>,
+    config: Option<&PyMetricConfig>,
+) -> PyResult<PyQualityMetrics> {
+    let rust_config = config.map(MetricConfig::from).unwrap_or_default();
+    let rust_chunks: Vec<ChunkForEval> = chunks.iter().map(ChunkForEval::from).collect();
+    let text_owned = original_text.to_string();
+
+    let _ = py;
+    if let Ok(p) = provider.cast::<PyOllamaProvider>() {
+        let provider_ref = p.borrow();
+        return run_evaluate(&text_owned, &rust_chunks, &provider_ref.inner, &rust_config);
+    }
+    if let Ok(p) = provider.cast::<PyOpenAiProvider>() {
+        let provider_ref = p.borrow();
+        return run_evaluate(&text_owned, &rust_chunks, &provider_ref.inner, &rust_config);
+    }
+    if let Ok(p) = provider.cast::<PyOnnxProvider>() {
+        let provider_ref = p.borrow();
+        return run_evaluate(&text_owned, &rust_chunks, &provider_ref.inner, &rust_config);
+    }
+
+    Err(pyo3::exceptions::PyTypeError::new_err(
+        "provider must be OllamaProvider, OpenAiProvider, or OnnxProvider",
+    ))
+}
+
+fn run_evaluate<P: EmbeddingProvider>(
+    original_text: &str,
+    chunks: &[ChunkForEval],
+    provider: &P,
+    config: &MetricConfig,
+) -> PyResult<PyQualityMetrics> {
+    let metrics = RUNTIME
+        .block_on(async { evaluate_chunks(original_text, chunks, provider, config).await })
+        .map_err(to_py_err)?;
+
+    Ok(PyQualityMetrics::from(metrics))
+}

--- a/packages/python/src/topo.rs
+++ b/packages/python/src/topo.rs
@@ -1,0 +1,160 @@
+//! Python bindings for topology-aware chunking.
+
+use pyo3::prelude::*;
+
+use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
+use cognigraph_chunker::semantic::topo_chunk::{TopoConfig as RustTopoConfig, topo_chunk};
+use cognigraph_chunker::semantic::topo_types::{SectionClass, SectionClassification, TopoChunk};
+
+use crate::error::to_py_err;
+use crate::semantic::RUNTIME;
+
+/// Configuration for topology-aware chunking.
+#[pyclass(name = "TopoConfig", from_py_object)]
+#[derive(Clone)]
+pub struct PyTopoConfig {
+    #[pyo3(get, set)]
+    pub soft_budget: usize,
+    #[pyo3(get, set)]
+    pub hard_budget: usize,
+    #[pyo3(get, set)]
+    pub emit_sir: bool,
+}
+
+#[pymethods]
+impl PyTopoConfig {
+    #[new]
+    #[pyo3(signature = (*, soft_budget=512, hard_budget=768, emit_sir=false))]
+    fn new(soft_budget: usize, hard_budget: usize, emit_sir: bool) -> Self {
+        Self {
+            soft_budget,
+            hard_budget,
+            emit_sir,
+        }
+    }
+}
+
+impl From<&PyTopoConfig> for RustTopoConfig {
+    fn from(py: &PyTopoConfig) -> Self {
+        Self {
+            soft_budget: py.soft_budget,
+            hard_budget: py.hard_budget,
+            emit_sir: py.emit_sir,
+        }
+    }
+}
+
+/// A section classification returned to Python.
+#[pyclass(name = "SectionClassification", from_py_object)]
+#[derive(Clone)]
+pub struct PySectionClassification {
+    #[pyo3(get)]
+    pub section_id: usize,
+    #[pyo3(get)]
+    pub class: String,
+    #[pyo3(get)]
+    pub reason: String,
+}
+
+/// A topology-aware chunk returned to Python.
+#[pyclass(name = "TopoChunk", from_py_object)]
+#[derive(Clone)]
+pub struct PyTopoChunk {
+    #[pyo3(get)]
+    pub text: String,
+    #[pyo3(get)]
+    pub offset_start: usize,
+    #[pyo3(get)]
+    pub offset_end: usize,
+    #[pyo3(get)]
+    pub token_estimate: usize,
+    #[pyo3(get)]
+    pub heading_path: Vec<String>,
+    #[pyo3(get)]
+    pub section_classification: String,
+    #[pyo3(get)]
+    pub cross_references: Vec<usize>,
+}
+
+/// Result of topology-aware chunking.
+#[pyclass(name = "TopoResult")]
+pub struct PyTopoResult {
+    #[pyo3(get)]
+    pub chunks: Vec<PyTopoChunk>,
+    #[pyo3(get)]
+    pub classifications: Vec<PySectionClassification>,
+    #[pyo3(get)]
+    pub block_count: usize,
+    #[pyo3(get)]
+    pub sir_json: Option<String>,
+}
+
+fn section_class_to_str(class: SectionClass) -> &'static str {
+    match class {
+        SectionClass::Atomic => "atomic",
+        SectionClass::Splittable => "splittable",
+        SectionClass::MergeCandidate => "merge_candidate",
+    }
+}
+
+fn convert_chunk(c: TopoChunk) -> PyTopoChunk {
+    PyTopoChunk {
+        text: c.text,
+        offset_start: c.offset_start,
+        offset_end: c.offset_end,
+        token_estimate: c.token_estimate,
+        heading_path: c.heading_path,
+        section_classification: c.section_classification,
+        cross_references: c.cross_references,
+    }
+}
+
+fn convert_classification(sc: SectionClassification) -> PySectionClassification {
+    PySectionClassification {
+        section_id: sc.section_id,
+        class: section_class_to_str(sc.class).to_string(),
+        reason: sc.reason,
+    }
+}
+
+/// Run topology-aware chunking.
+#[pyfunction]
+#[pyo3(signature = (text, api_key, base_url=None, model=None, config=None))]
+pub fn py_topo_chunk(
+    _py: Python<'_>,
+    text: &str,
+    api_key: String,
+    base_url: Option<String>,
+    model: Option<String>,
+    config: Option<&PyTopoConfig>,
+) -> PyResult<PyTopoResult> {
+    let rust_config = config.map(RustTopoConfig::from).unwrap_or_default();
+    let text_owned = text.to_string();
+
+    let llm_config = LlmConfig::resolve(&Some(api_key), &base_url, &model).map_err(to_py_err)?;
+    let llm_client = CompletionClient::new(llm_config).map_err(to_py_err)?;
+
+    let result = RUNTIME
+        .block_on(async { topo_chunk(&text_owned, &llm_client, &rust_config).await })
+        .map_err(to_py_err)?;
+
+    let sir_json = if rust_config.emit_sir {
+        serde_json::to_string(&result.sir).ok()
+    } else {
+        None
+    };
+
+    let chunks = result.chunks.into_iter().map(convert_chunk).collect();
+    let classifications = result
+        .classifications
+        .into_iter()
+        .map(convert_classification)
+        .collect();
+
+    Ok(PyTopoResult {
+        chunks,
+        classifications,
+        block_count: result.block_count,
+        sir_json,
+    })
+}

--- a/src/api/adaptive.rs
+++ b/src/api/adaptive.rs
@@ -1,0 +1,214 @@
+//! POST /api/v1/adaptive handler.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use serde::Deserialize;
+
+use crate::embeddings::EmbeddingProvider;
+use crate::embeddings::cloudflare::{CloudflareProvider, resolve_cloudflare_credentials};
+use crate::embeddings::oauth::{OAuthProvider, resolve_oauth_credentials};
+use crate::embeddings::ollama::OllamaProvider;
+use crate::embeddings::onnx::OnnxProvider;
+use crate::embeddings::openai::OpenAiProvider;
+use crate::llm::{CompletionClient, LlmConfig};
+use crate::semantic::adaptive_chunk::{AdaptiveConfig, adaptive_chunk};
+use crate::semantic::adaptive_types::AdaptiveResult;
+use crate::semantic::quality_metrics::MetricWeights;
+
+use super::AppState;
+use super::errors::ApiError;
+use super::semantic::{ProviderParam, validate_base_url};
+
+fn default_provider() -> ProviderParam {
+    ProviderParam::Ollama
+}
+fn default_soft_budget() -> usize {
+    512
+}
+fn default_hard_budget() -> usize {
+    768
+}
+fn default_sim_window() -> usize {
+    3
+}
+fn default_sg_window() -> usize {
+    11
+}
+fn default_poly_order() -> usize {
+    3
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AdaptiveRequest {
+    pub text: String,
+    #[serde(default = "default_provider")]
+    pub provider: ProviderParam,
+    pub model: Option<String>,
+    pub api_key: Option<String>,
+    pub base_url: Option<String>,
+    pub model_path: Option<String>,
+    pub cf_auth_token: Option<String>,
+    pub cf_account_id: Option<String>,
+    pub cf_ai_gateway: Option<String>,
+    pub oauth_token_url: Option<String>,
+    pub oauth_client_id: Option<String>,
+    pub oauth_client_secret: Option<String>,
+    pub oauth_scope: Option<String>,
+    pub oauth_base_url: Option<String>,
+    #[serde(default)]
+    pub danger_accept_invalid_certs: bool,
+    #[serde(default = "default_soft_budget")]
+    pub soft_budget: usize,
+    #[serde(default = "default_hard_budget")]
+    pub hard_budget: usize,
+    #[serde(default = "default_sim_window")]
+    pub sim_window: usize,
+    #[serde(default = "default_sg_window")]
+    pub sg_window: usize,
+    #[serde(default = "default_poly_order")]
+    pub poly_order: usize,
+    /// Comma-separated candidate methods (default: "semantic,cognitive").
+    pub candidates: Option<String>,
+    /// Bypass pre-screening heuristics.
+    #[serde(default)]
+    pub force_candidates: bool,
+    /// Custom metric weights for composite scoring.
+    pub metric_weights: Option<MetricWeights>,
+    /// Include full quality report in response.
+    #[serde(default)]
+    pub include_report: bool,
+    /// LLM model for intent/enriched/topo methods.
+    pub llm_model: Option<String>,
+    /// LLM base URL override.
+    pub llm_base_url: Option<String>,
+}
+
+pub async fn adaptive_handler(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<AdaptiveRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    if let Some(ref base_url) = req.base_url {
+        validate_base_url(base_url, state.allow_private_urls)?;
+    }
+
+    let candidates: Vec<String> = if let Some(ref c) = req.candidates {
+        c.split(',').map(|s| s.trim().to_string()).collect()
+    } else {
+        vec!["semantic".to_string(), "cognitive".to_string()]
+    };
+
+    let metric_weights = req.metric_weights.clone().unwrap_or_default();
+
+    let config = AdaptiveConfig {
+        candidates,
+        force_candidates: req.force_candidates,
+        soft_budget: req.soft_budget,
+        hard_budget: req.hard_budget,
+        metric_weights,
+        sim_window: req.sim_window,
+        sg_window: req.sg_window,
+        poly_order: req.poly_order,
+    };
+
+    // Build optional LLM client
+    let llm_client = match LlmConfig::resolve(&req.api_key, &req.llm_base_url, &req.llm_model) {
+        Ok(llm_config) => CompletionClient::new(llm_config).ok(),
+        Err(_) => None,
+    };
+
+    let result = match req.provider {
+        ProviderParam::Ollama => {
+            let provider = OllamaProvider::new(req.base_url.clone(), req.model.clone())?;
+            run_adaptive(&req.text, &provider, llm_client.as_ref(), &config).await?
+        }
+        ProviderParam::Openai => {
+            let api_key = resolve_openai_key(&req.api_key)?;
+            let provider = OpenAiProvider::new(api_key, req.base_url.clone(), req.model.clone())?;
+            run_adaptive(&req.text, &provider, llm_client.as_ref(), &config).await?
+        }
+        ProviderParam::Onnx => {
+            let model_path = req
+                .model_path
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("model_path is required for onnx provider"))?;
+            let provider = OnnxProvider::new(model_path)?;
+            run_adaptive(&req.text, &provider, llm_client.as_ref(), &config).await?
+        }
+        ProviderParam::Cloudflare => {
+            let (token, account_id, gateway) = resolve_cloudflare_credentials(
+                &req.cf_auth_token,
+                &req.cf_account_id,
+                &req.cf_ai_gateway,
+            )?;
+            let provider = CloudflareProvider::new(token, account_id, req.model.clone(), gateway)?;
+            provider.verify_token().await?;
+            run_adaptive(&req.text, &provider, llm_client.as_ref(), &config).await?
+        }
+        ProviderParam::Oauth => {
+            let creds = resolve_oauth_credentials(
+                &req.oauth_token_url,
+                &req.oauth_client_id,
+                &req.oauth_client_secret,
+                &req.oauth_scope,
+                &req.oauth_base_url,
+                &req.model,
+            )?;
+            let provider = OAuthProvider::new(
+                creds.token_url,
+                creds.client_id,
+                creds.client_secret,
+                creds.scope,
+                creds.base_url,
+                creds.model,
+                req.danger_accept_invalid_certs,
+            )?;
+            provider.verify_credentials().await?;
+            run_adaptive(&req.text, &provider, llm_client.as_ref(), &config).await?
+        }
+    };
+
+    if req.include_report {
+        Ok(Json(serde_json::to_value(&result).unwrap()))
+    } else {
+        let output = serde_json::json!({
+            "winner": result.winner,
+            "chunks": result.chunks,
+            "count": result.count,
+        });
+        Ok(Json(output))
+    }
+}
+
+async fn run_adaptive<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: Option<&CompletionClient>,
+    config: &AdaptiveConfig,
+) -> anyhow::Result<AdaptiveResult> {
+    adaptive_chunk(text, provider, llm_client, config).await
+}
+
+fn resolve_openai_key(flag: &Option<String>) -> anyhow::Result<String> {
+    if let Some(key) = flag {
+        return Ok(key.clone());
+    }
+    if let Ok(key) = std::env::var("OPENAI_API_KEY")
+        && !key.is_empty()
+    {
+        return Ok(key);
+    }
+    if let Ok(content) = std::fs::read_to_string(".env.openai") {
+        for line in content.lines() {
+            let line = line.trim();
+            if let Some(val) = line.strip_prefix("OPENAI_API_KEY=") {
+                let val = val.trim();
+                if !val.is_empty() {
+                    return Ok(val.to_string());
+                }
+            }
+        }
+    }
+    anyhow::bail!("OpenAI API key not found.")
+}

--- a/src/api/enriched.rs
+++ b/src/api/enriched.rs
@@ -1,0 +1,128 @@
+//! POST /api/v1/enriched handler.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use serde::{Deserialize, Serialize};
+
+use crate::llm::{CompletionClient, LlmConfig};
+use crate::semantic::enriched_chunk::{EnrichedConfig, enriched_chunk, enriched_chunk_plain};
+use crate::semantic::enriched_types::TypedEntity;
+
+use super::AppState;
+use super::errors::ApiError;
+
+fn default_soft_budget() -> usize {
+    512
+}
+fn default_hard_budget() -> usize {
+    768
+}
+fn default_recombine() -> bool {
+    true
+}
+fn default_re_enrich() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EnrichedRequest {
+    pub text: String,
+    pub enrichment_model: Option<String>,
+    pub api_key: Option<String>,
+    pub llm_base_url: Option<String>,
+    #[serde(default = "default_soft_budget")]
+    pub soft_budget: usize,
+    #[serde(default = "default_hard_budget")]
+    pub hard_budget: usize,
+    #[serde(default = "default_recombine")]
+    pub recombine: bool,
+    #[serde(default = "default_re_enrich")]
+    pub re_enrich: bool,
+    #[serde(default)]
+    pub no_markdown: bool,
+}
+
+#[derive(Serialize)]
+pub struct EnrichedResponse {
+    pub chunks: Vec<EnrichedChunkEntry>,
+    pub count: usize,
+    pub block_count: usize,
+    pub key_dictionary: std::collections::HashMap<String, Vec<usize>>,
+}
+
+#[derive(Serialize)]
+pub struct EnrichedChunkEntry {
+    pub index: usize,
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+    pub length: usize,
+    pub token_estimate: usize,
+    pub title: String,
+    pub summary: String,
+    pub keywords: Vec<String>,
+    pub typed_entities: Vec<TypedEntity>,
+    pub hypothetical_questions: Vec<String>,
+    pub semantic_keys: Vec<String>,
+    pub category: String,
+    pub heading_path: Vec<String>,
+}
+
+pub async fn enriched_handler(
+    State(_state): State<Arc<AppState>>,
+    Json(req): Json<EnrichedRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let llm_config = LlmConfig::resolve(
+        &req.api_key,
+        &req.llm_base_url,
+        &req.enrichment_model,
+    )?;
+    let llm_client = CompletionClient::new(llm_config)?;
+
+    let config = EnrichedConfig {
+        soft_budget: req.soft_budget,
+        hard_budget: req.hard_budget,
+        recombine: req.recombine,
+        re_enrich: req.re_enrich,
+    };
+
+    let result = if req.no_markdown {
+        enriched_chunk_plain(&req.text, &llm_client, &config).await?
+    } else {
+        enriched_chunk(&req.text, &llm_client, &config).await?
+    };
+
+    let chunks: Vec<EnrichedChunkEntry> = result
+        .chunks
+        .iter()
+        .enumerate()
+        .map(|(i, c)| EnrichedChunkEntry {
+            index: i,
+            text: c.text.clone(),
+            offset_start: c.offset_start,
+            offset_end: c.offset_end,
+            length: c.text.len(),
+            token_estimate: c.token_estimate,
+            title: c.title.clone(),
+            summary: c.summary.clone(),
+            keywords: c.keywords.clone(),
+            typed_entities: c.typed_entities.clone(),
+            hypothetical_questions: c.hypothetical_questions.clone(),
+            semantic_keys: c.semantic_keys.clone(),
+            category: c.category.clone(),
+            heading_path: c.heading_path.clone(),
+        })
+        .collect();
+
+    let count = chunks.len();
+    let response = EnrichedResponse {
+        chunks,
+        count,
+        block_count: result.block_count,
+        key_dictionary: result.key_dictionary,
+    };
+
+    Ok(Json(serde_json::to_value(response).unwrap()))
+}

--- a/src/api/enriched.rs
+++ b/src/api/enriched.rs
@@ -74,11 +74,7 @@ pub async fn enriched_handler(
     State(_state): State<Arc<AppState>>,
     Json(req): Json<EnrichedRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let llm_config = LlmConfig::resolve(
-        &req.api_key,
-        &req.llm_base_url,
-        &req.enrichment_model,
-    )?;
+    let llm_config = LlmConfig::resolve(&req.api_key, &req.llm_base_url, &req.enrichment_model)?;
     let llm_client = CompletionClient::new(llm_config)?;
 
     let config = EnrichedConfig {

--- a/src/api/evaluate.rs
+++ b/src/api/evaluate.rs
@@ -6,7 +6,6 @@ use axum::Json;
 use axum::extract::State;
 use serde::{Deserialize, Serialize};
 
-use crate::embeddings::EmbeddingProvider;
 use crate::embeddings::cloudflare::{CloudflareProvider, resolve_cloudflare_credentials};
 use crate::embeddings::oauth::{OAuthProvider, resolve_oauth_credentials};
 use crate::embeddings::ollama::OllamaProvider;
@@ -88,12 +87,12 @@ pub async fn evaluate_handler(
     let metrics = match req.provider {
         ProviderParam::Ollama => {
             let provider = OllamaProvider::new(req.base_url.clone(), req.model.clone())?;
-            run_evaluate(&req.text, &req.chunks, &provider, &config).await?
+            evaluate_chunks(&req.text, &req.chunks, &provider, &config).await?
         }
         ProviderParam::Openai => {
             let api_key = resolve_openai_key(&req.api_key)?;
             let provider = OpenAiProvider::new(api_key, req.base_url.clone(), req.model.clone())?;
-            run_evaluate(&req.text, &req.chunks, &provider, &config).await?
+            evaluate_chunks(&req.text, &req.chunks, &provider, &config).await?
         }
         ProviderParam::Onnx => {
             let model_path = req
@@ -101,7 +100,7 @@ pub async fn evaluate_handler(
                 .as_deref()
                 .ok_or_else(|| anyhow::anyhow!("model_path is required for onnx provider"))?;
             let provider = OnnxProvider::new(model_path)?;
-            run_evaluate(&req.text, &req.chunks, &provider, &config).await?
+            evaluate_chunks(&req.text, &req.chunks, &provider, &config).await?
         }
         ProviderParam::Cloudflare => {
             let (token, account_id, gateway) = resolve_cloudflare_credentials(
@@ -111,7 +110,7 @@ pub async fn evaluate_handler(
             )?;
             let provider = CloudflareProvider::new(token, account_id, req.model.clone(), gateway)?;
             provider.verify_token().await?;
-            run_evaluate(&req.text, &req.chunks, &provider, &config).await?
+            evaluate_chunks(&req.text, &req.chunks, &provider, &config).await?
         }
         ProviderParam::Oauth => {
             let creds = resolve_oauth_credentials(
@@ -132,7 +131,7 @@ pub async fn evaluate_handler(
                 req.danger_accept_invalid_certs,
             )?;
             provider.verify_credentials().await?;
-            run_evaluate(&req.text, &req.chunks, &provider, &config).await?
+            evaluate_chunks(&req.text, &req.chunks, &provider, &config).await?
         }
     };
 
@@ -140,15 +139,6 @@ pub async fn evaluate_handler(
         metrics,
         chunk_count,
     }))
-}
-
-async fn run_evaluate<P: EmbeddingProvider>(
-    text: &str,
-    chunks: &[ChunkForEval],
-    provider: &P,
-    config: &MetricConfig,
-) -> anyhow::Result<QualityMetrics> {
-    evaluate_chunks(text, chunks, provider, config).await
 }
 
 /// Resolve OpenAI API key from request field, env var, or .env.openai file.

--- a/src/api/evaluate.rs
+++ b/src/api/evaluate.rs
@@ -1,0 +1,176 @@
+//! POST /api/v1/evaluate handler — intrinsic quality metrics for chunking output.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use serde::{Deserialize, Serialize};
+
+use crate::embeddings::EmbeddingProvider;
+use crate::embeddings::cloudflare::{CloudflareProvider, resolve_cloudflare_credentials};
+use crate::embeddings::oauth::{OAuthProvider, resolve_oauth_credentials};
+use crate::embeddings::ollama::OllamaProvider;
+use crate::embeddings::onnx::OnnxProvider;
+use crate::embeddings::openai::OpenAiProvider;
+use crate::semantic::quality_metrics::{
+    ChunkForEval, MetricConfig, MetricWeights, QualityMetrics, evaluate_chunks,
+};
+
+use super::AppState;
+use super::errors::ApiError;
+use super::semantic::{ProviderParam, validate_base_url};
+
+fn default_provider() -> ProviderParam {
+    ProviderParam::Ollama
+}
+
+fn default_soft_budget() -> usize {
+    512
+}
+
+fn default_hard_budget() -> usize {
+    768
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EvaluateRequest {
+    /// The original document text (used for block integrity analysis).
+    pub text: String,
+    /// The chunks to evaluate.
+    pub chunks: Vec<ChunkForEval>,
+    /// Embedding provider to use for cohesion and coherence metrics.
+    #[serde(default = "default_provider")]
+    pub provider: ProviderParam,
+    pub model: Option<String>,
+    pub api_key: Option<String>,
+    pub base_url: Option<String>,
+    pub model_path: Option<String>,
+    pub cf_auth_token: Option<String>,
+    pub cf_account_id: Option<String>,
+    pub cf_ai_gateway: Option<String>,
+    pub oauth_token_url: Option<String>,
+    pub oauth_client_id: Option<String>,
+    pub oauth_client_secret: Option<String>,
+    pub oauth_scope: Option<String>,
+    pub oauth_base_url: Option<String>,
+    #[serde(default)]
+    pub danger_accept_invalid_certs: bool,
+    #[serde(default = "default_soft_budget")]
+    pub soft_budget: usize,
+    #[serde(default = "default_hard_budget")]
+    pub hard_budget: usize,
+    /// Optional custom metric weights. Defaults to 0.20 for each metric.
+    pub metric_weights: Option<MetricWeights>,
+}
+
+#[derive(Serialize)]
+pub struct EvaluateResponse {
+    pub metrics: QualityMetrics,
+    pub chunk_count: usize,
+}
+
+pub async fn evaluate_handler(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<EvaluateRequest>,
+) -> Result<Json<EvaluateResponse>, ApiError> {
+    if let Some(ref base_url) = req.base_url {
+        validate_base_url(base_url, state.allow_private_urls)?;
+    }
+
+    let config = MetricConfig {
+        soft_budget: req.soft_budget,
+        hard_budget: req.hard_budget,
+        weights: req.metric_weights.unwrap_or_default(),
+    };
+
+    let chunk_count = req.chunks.len();
+
+    let metrics = match req.provider {
+        ProviderParam::Ollama => {
+            let provider = OllamaProvider::new(req.base_url.clone(), req.model.clone())?;
+            run_evaluate(&req.text, &req.chunks, &provider, &config).await?
+        }
+        ProviderParam::Openai => {
+            let api_key = resolve_openai_key(&req.api_key)?;
+            let provider = OpenAiProvider::new(api_key, req.base_url.clone(), req.model.clone())?;
+            run_evaluate(&req.text, &req.chunks, &provider, &config).await?
+        }
+        ProviderParam::Onnx => {
+            let model_path = req
+                .model_path
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("model_path is required for onnx provider"))?;
+            let provider = OnnxProvider::new(model_path)?;
+            run_evaluate(&req.text, &req.chunks, &provider, &config).await?
+        }
+        ProviderParam::Cloudflare => {
+            let (token, account_id, gateway) = resolve_cloudflare_credentials(
+                &req.cf_auth_token,
+                &req.cf_account_id,
+                &req.cf_ai_gateway,
+            )?;
+            let provider = CloudflareProvider::new(token, account_id, req.model.clone(), gateway)?;
+            provider.verify_token().await?;
+            run_evaluate(&req.text, &req.chunks, &provider, &config).await?
+        }
+        ProviderParam::Oauth => {
+            let creds = resolve_oauth_credentials(
+                &req.oauth_token_url,
+                &req.oauth_client_id,
+                &req.oauth_client_secret,
+                &req.oauth_scope,
+                &req.oauth_base_url,
+                &req.model,
+            )?;
+            let provider = OAuthProvider::new(
+                creds.token_url,
+                creds.client_id,
+                creds.client_secret,
+                creds.scope,
+                creds.base_url,
+                creds.model,
+                req.danger_accept_invalid_certs,
+            )?;
+            provider.verify_credentials().await?;
+            run_evaluate(&req.text, &req.chunks, &provider, &config).await?
+        }
+    };
+
+    Ok(Json(EvaluateResponse {
+        metrics,
+        chunk_count,
+    }))
+}
+
+async fn run_evaluate<P: EmbeddingProvider>(
+    text: &str,
+    chunks: &[ChunkForEval],
+    provider: &P,
+    config: &MetricConfig,
+) -> anyhow::Result<QualityMetrics> {
+    evaluate_chunks(text, chunks, provider, config).await
+}
+
+/// Resolve OpenAI API key from request field, env var, or .env.openai file.
+fn resolve_openai_key(flag: &Option<String>) -> anyhow::Result<String> {
+    if let Some(key) = flag {
+        return Ok(key.clone());
+    }
+    if let Ok(key) = std::env::var("OPENAI_API_KEY")
+        && !key.is_empty()
+    {
+        return Ok(key);
+    }
+    if let Ok(content) = std::fs::read_to_string(".env.openai") {
+        for line in content.lines() {
+            let line = line.trim();
+            if let Some(val) = line.strip_prefix("OPENAI_API_KEY=") {
+                let val = val.trim();
+                if !val.is_empty() {
+                    return Ok(val.to_string());
+                }
+            }
+        }
+    }
+    anyhow::bail!("OpenAI API key not found.")
+}

--- a/src/api/intent.rs
+++ b/src/api/intent.rs
@@ -99,11 +99,7 @@ pub async fn intent_handler(
     }
 
     // Resolve LLM config for intent generation
-    let llm_config = LlmConfig::resolve(
-        &req.api_key,
-        &req.llm_base_url,
-        &req.intent_model,
-    )?;
+    let llm_config = LlmConfig::resolve(&req.api_key, &req.llm_base_url, &req.intent_model)?;
     let llm_client = CompletionClient::new(llm_config)?;
 
     let config = IntentConfig {

--- a/src/api/intent.rs
+++ b/src/api/intent.rs
@@ -1,0 +1,233 @@
+//! POST /api/v1/intent handler.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use serde::{Deserialize, Serialize};
+
+use crate::embeddings::EmbeddingProvider;
+use crate::embeddings::cloudflare::{CloudflareProvider, resolve_cloudflare_credentials};
+use crate::embeddings::oauth::{OAuthProvider, resolve_oauth_credentials};
+use crate::embeddings::ollama::OllamaProvider;
+use crate::embeddings::onnx::OnnxProvider;
+use crate::embeddings::openai::OpenAiProvider;
+use crate::llm::{CompletionClient, LlmConfig};
+use crate::semantic::intent_chunk::{IntentConfig, intent_chunk, intent_chunk_plain};
+use crate::semantic::intent_types::{IntentResult, PredictedIntent};
+
+use super::AppState;
+use super::errors::ApiError;
+use super::semantic::{ProviderParam, validate_base_url};
+
+fn default_provider() -> ProviderParam {
+    ProviderParam::Ollama
+}
+fn default_soft_budget() -> usize {
+    512
+}
+fn default_hard_budget() -> usize {
+    768
+}
+fn default_max_intents() -> usize {
+    20
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IntentRequest {
+    pub text: String,
+    #[serde(default = "default_provider")]
+    pub provider: ProviderParam,
+    pub model: Option<String>,
+    pub api_key: Option<String>,
+    pub base_url: Option<String>,
+    pub model_path: Option<String>,
+    pub cf_auth_token: Option<String>,
+    pub cf_account_id: Option<String>,
+    pub cf_ai_gateway: Option<String>,
+    pub oauth_token_url: Option<String>,
+    pub oauth_client_id: Option<String>,
+    pub oauth_client_secret: Option<String>,
+    pub oauth_scope: Option<String>,
+    pub oauth_base_url: Option<String>,
+    #[serde(default)]
+    pub danger_accept_invalid_certs: bool,
+    #[serde(default = "default_soft_budget")]
+    pub soft_budget: usize,
+    #[serde(default = "default_hard_budget")]
+    pub hard_budget: usize,
+    /// LLM model for intent generation (default: gpt-4.1-mini).
+    pub intent_model: Option<String>,
+    /// Maximum number of intents to generate.
+    #[serde(default = "default_max_intents")]
+    pub max_intents: usize,
+    /// Base URL for the LLM API (defaults to OpenAI).
+    pub llm_base_url: Option<String>,
+    #[serde(default)]
+    pub no_markdown: bool,
+}
+
+#[derive(Serialize)]
+pub struct IntentResponse {
+    pub chunks: Vec<IntentChunkEntry>,
+    pub intents: Vec<PredictedIntent>,
+    pub partition_score: f64,
+    pub count: usize,
+    pub block_count: usize,
+}
+
+#[derive(Serialize)]
+pub struct IntentChunkEntry {
+    pub index: usize,
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+    pub length: usize,
+    pub token_estimate: usize,
+    pub best_intent: usize,
+    pub alignment_score: f64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub heading_path: Vec<String>,
+}
+
+pub async fn intent_handler(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<IntentRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    if let Some(ref base_url) = req.base_url {
+        validate_base_url(base_url, state.allow_private_urls)?;
+    }
+
+    // Resolve LLM config for intent generation
+    let llm_config = LlmConfig::resolve(
+        &req.api_key,
+        &req.llm_base_url,
+        &req.intent_model,
+    )?;
+    let llm_client = CompletionClient::new(llm_config)?;
+
+    let config = IntentConfig {
+        max_intents: req.max_intents,
+        soft_budget: req.soft_budget,
+        hard_budget: req.hard_budget,
+    };
+
+    let result = match req.provider {
+        ProviderParam::Ollama => {
+            let provider = OllamaProvider::new(req.base_url.clone(), req.model.clone())?;
+            run_intent(&req.text, &provider, &llm_client, &config, req.no_markdown).await?
+        }
+        ProviderParam::Openai => {
+            let api_key = resolve_openai_key(&req.api_key)?;
+            let provider = OpenAiProvider::new(api_key, req.base_url.clone(), req.model.clone())?;
+            run_intent(&req.text, &provider, &llm_client, &config, req.no_markdown).await?
+        }
+        ProviderParam::Onnx => {
+            let model_path = req
+                .model_path
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("model_path is required for onnx provider"))?;
+            let provider = OnnxProvider::new(model_path)?;
+            run_intent(&req.text, &provider, &llm_client, &config, req.no_markdown).await?
+        }
+        ProviderParam::Cloudflare => {
+            let (token, account_id, gateway) = resolve_cloudflare_credentials(
+                &req.cf_auth_token,
+                &req.cf_account_id,
+                &req.cf_ai_gateway,
+            )?;
+            let provider = CloudflareProvider::new(token, account_id, req.model.clone(), gateway)?;
+            provider.verify_token().await?;
+            run_intent(&req.text, &provider, &llm_client, &config, req.no_markdown).await?
+        }
+        ProviderParam::Oauth => {
+            let creds = resolve_oauth_credentials(
+                &req.oauth_token_url,
+                &req.oauth_client_id,
+                &req.oauth_client_secret,
+                &req.oauth_scope,
+                &req.oauth_base_url,
+                &req.model,
+            )?;
+            let provider = OAuthProvider::new(
+                creds.token_url,
+                creds.client_id,
+                creds.client_secret,
+                creds.scope,
+                creds.base_url,
+                creds.model,
+                req.danger_accept_invalid_certs,
+            )?;
+            provider.verify_credentials().await?;
+            run_intent(&req.text, &provider, &llm_client, &config, req.no_markdown).await?
+        }
+    };
+
+    let response = build_response(result);
+    Ok(Json(serde_json::to_value(response).unwrap()))
+}
+
+async fn run_intent<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: &CompletionClient,
+    config: &IntentConfig,
+    no_markdown: bool,
+) -> anyhow::Result<IntentResult> {
+    if no_markdown {
+        intent_chunk_plain(text, provider, llm_client, config).await
+    } else {
+        intent_chunk(text, provider, llm_client, config).await
+    }
+}
+
+fn build_response(result: IntentResult) -> IntentResponse {
+    let chunks: Vec<IntentChunkEntry> = result
+        .chunks
+        .iter()
+        .enumerate()
+        .map(|(i, c)| IntentChunkEntry {
+            index: i,
+            text: c.text.clone(),
+            offset_start: c.offset_start,
+            offset_end: c.offset_end,
+            length: c.text.len(),
+            token_estimate: c.token_estimate,
+            best_intent: c.best_intent,
+            alignment_score: c.alignment_score,
+            heading_path: c.heading_path.clone(),
+        })
+        .collect();
+
+    let count = chunks.len();
+    IntentResponse {
+        chunks,
+        intents: result.intents,
+        partition_score: result.partition_score,
+        count,
+        block_count: result.block_count,
+    }
+}
+
+fn resolve_openai_key(flag: &Option<String>) -> anyhow::Result<String> {
+    if let Some(key) = flag {
+        return Ok(key.clone());
+    }
+    if let Ok(key) = std::env::var("OPENAI_API_KEY")
+        && !key.is_empty()
+    {
+        return Ok(key);
+    }
+    if let Ok(content) = std::fs::read_to_string(".env.openai") {
+        for line in content.lines() {
+            let line = line.trim();
+            if let Some(val) = line.strip_prefix("OPENAI_API_KEY=") {
+                let val = val.trim();
+                if !val.is_empty() {
+                    return Ok(val.to_string());
+                }
+            }
+        }
+    }
+    anyhow::bail!("OpenAI API key not found.")
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,7 @@ pub mod cognitive;
 pub mod errors;
 pub mod evaluate;
 pub mod health;
+pub mod intent;
 pub mod merge;
 pub mod semantic;
 pub mod split;
@@ -76,6 +77,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/api/v1/cognitive",
             axum::routing::post(cognitive::cognitive_handler),
+        )
+        .route(
+            "/api/v1/intent",
+            axum::routing::post(intent::intent_handler),
         )
         .route("/api/v1/merge", axum::routing::post(merge::merge_handler))
         .route(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -10,6 +10,7 @@ pub mod intent;
 pub mod merge;
 pub mod semantic;
 pub mod split;
+pub mod topo;
 pub mod types;
 
 use std::sync::Arc;
@@ -91,6 +92,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/api/v1/evaluate",
             axum::routing::post(evaluate::evaluate_handler),
+        )
+        .route(
+            "/api/v1/topo",
+            axum::routing::post(topo::topo_handler),
         )
         .layer(middleware::from_fn_with_state(
             shared_state.clone(),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,6 @@
 //! REST API module — Axum router setup and shared state.
 
+pub mod adaptive;
 pub mod chunk;
 pub mod cognitive;
 pub mod enriched;
@@ -96,6 +97,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/api/v1/topo",
             axum::routing::post(topo::topo_handler),
+        )
+        .route(
+            "/api/v1/adaptive",
+            axum::routing::post(adaptive::adaptive_handler),
         )
         .layer(middleware::from_fn_with_state(
             shared_state.clone(),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -94,10 +94,7 @@ pub fn router(state: AppState) -> Router {
             "/api/v1/evaluate",
             axum::routing::post(evaluate::evaluate_handler),
         )
-        .route(
-            "/api/v1/topo",
-            axum::routing::post(topo::topo_handler),
-        )
+        .route("/api/v1/topo", axum::routing::post(topo::topo_handler))
         .route(
             "/api/v1/adaptive",
             axum::routing::post(adaptive::adaptive_handler),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,6 +3,7 @@
 pub mod chunk;
 pub mod cognitive;
 pub mod errors;
+pub mod evaluate;
 pub mod health;
 pub mod merge;
 pub mod semantic;
@@ -77,6 +78,10 @@ pub fn router(state: AppState) -> Router {
             axum::routing::post(cognitive::cognitive_handler),
         )
         .route("/api/v1/merge", axum::routing::post(merge::merge_handler))
+        .route(
+            "/api/v1/evaluate",
+            axum::routing::post(evaluate::evaluate_handler),
+        )
         .layer(middleware::from_fn_with_state(
             shared_state.clone(),
             auth_middleware,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod chunk;
 pub mod cognitive;
+pub mod enriched;
 pub mod errors;
 pub mod evaluate;
 pub mod health;
@@ -83,6 +84,10 @@ pub fn router(state: AppState) -> Router {
             axum::routing::post(intent::intent_handler),
         )
         .route("/api/v1/merge", axum::routing::post(merge::merge_handler))
+        .route(
+            "/api/v1/enriched",
+            axum::routing::post(enriched::enriched_handler),
+        )
         .route(
             "/api/v1/evaluate",
             axum::routing::post(evaluate::evaluate_handler),

--- a/src/api/topo.rs
+++ b/src/api/topo.rs
@@ -1,0 +1,122 @@
+//! POST /api/v1/topo handler.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use serde::{Deserialize, Serialize};
+
+use crate::llm::{CompletionClient, LlmConfig};
+use crate::semantic::topo_chunk::{TopoConfig, topo_chunk};
+use crate::semantic::topo_types::TopoResult;
+
+use super::AppState;
+use super::errors::ApiError;
+
+fn default_soft_budget() -> usize {
+    512
+}
+fn default_hard_budget() -> usize {
+    768
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TopoRequest {
+    pub text: String,
+    /// LLM model for topology agents (default: gpt-4.1-mini).
+    pub topo_model: Option<String>,
+    /// API key for the LLM.
+    pub api_key: Option<String>,
+    /// Base URL for the LLM API.
+    pub llm_base_url: Option<String>,
+    /// Soft token budget per chunk.
+    #[serde(default = "default_soft_budget")]
+    pub soft_budget: usize,
+    /// Hard token ceiling per chunk.
+    #[serde(default = "default_hard_budget")]
+    pub hard_budget: usize,
+    /// Whether to emit the SIR in the response.
+    #[serde(default)]
+    pub emit_sir: bool,
+}
+
+#[derive(Serialize)]
+pub struct TopoResponse {
+    pub chunks: Vec<TopoChunkEntry>,
+    pub count: usize,
+    pub block_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sir: Option<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+pub struct TopoChunkEntry {
+    pub index: usize,
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+    pub length: usize,
+    pub token_estimate: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub heading_path: Vec<String>,
+    pub section_classification: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cross_references: Vec<usize>,
+}
+
+pub async fn topo_handler(
+    State(_state): State<Arc<AppState>>,
+    Json(req): Json<TopoRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    // Resolve LLM config
+    let llm_config = LlmConfig::resolve(
+        &req.api_key,
+        &req.llm_base_url,
+        &req.topo_model,
+    )?;
+    let llm_client = CompletionClient::new(llm_config)?;
+
+    let config = TopoConfig {
+        soft_budget: req.soft_budget,
+        hard_budget: req.hard_budget,
+        emit_sir: req.emit_sir,
+    };
+
+    let result = topo_chunk(&req.text, &llm_client, &config).await?;
+
+    let response = build_response(result, req.emit_sir);
+    Ok(Json(serde_json::to_value(response).unwrap()))
+}
+
+fn build_response(result: TopoResult, emit_sir: bool) -> TopoResponse {
+    let chunks: Vec<TopoChunkEntry> = result
+        .chunks
+        .iter()
+        .enumerate()
+        .map(|(i, c)| TopoChunkEntry {
+            index: i,
+            text: c.text.clone(),
+            offset_start: c.offset_start,
+            offset_end: c.offset_end,
+            length: c.text.len(),
+            token_estimate: c.token_estimate,
+            heading_path: c.heading_path.clone(),
+            section_classification: c.section_classification.clone(),
+            cross_references: c.cross_references.clone(),
+        })
+        .collect();
+
+    let count = chunks.len();
+    let sir = if emit_sir {
+        Some(serde_json::to_value(&result.sir).unwrap())
+    } else {
+        None
+    };
+
+    TopoResponse {
+        chunks,
+        count,
+        block_count: result.block_count,
+        sir,
+    }
+}

--- a/src/api/topo.rs
+++ b/src/api/topo.rs
@@ -69,11 +69,7 @@ pub async fn topo_handler(
     Json(req): Json<TopoRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     // Resolve LLM config
-    let llm_config = LlmConfig::resolve(
-        &req.api_key,
-        &req.llm_base_url,
-        &req.topo_model,
-    )?;
+    let llm_config = LlmConfig::resolve(&req.api_key, &req.llm_base_url, &req.topo_model)?;
     let llm_client = CompletionClient::new(llm_config)?;
 
     let config = TopoConfig {

--- a/src/cli/adaptive_cmd.rs
+++ b/src/cli/adaptive_cmd.rs
@@ -203,12 +203,28 @@ pub async fn run(args: &AdaptiveArgs, global: &GlobalOpts) -> anyhow::Result<()>
     match args.provider {
         ProviderType::Ollama => {
             let provider = OllamaProvider::new(args.base_url.clone(), args.model.clone())?;
-            run_adaptive(&text_str, &provider, llm_client.as_ref(), &config, args, global).await
+            run_adaptive(
+                &text_str,
+                &provider,
+                llm_client.as_ref(),
+                &config,
+                args,
+                global,
+            )
+            .await
         }
         ProviderType::Openai => {
             let api_key = resolve_openai_key(&args.api_key)?;
             let provider = OpenAiProvider::new(api_key, args.base_url.clone(), args.model.clone())?;
-            run_adaptive(&text_str, &provider, llm_client.as_ref(), &config, args, global).await
+            run_adaptive(
+                &text_str,
+                &provider,
+                llm_client.as_ref(),
+                &config,
+                args,
+                global,
+            )
+            .await
         }
         ProviderType::Onnx => {
             let model_path = args
@@ -216,7 +232,15 @@ pub async fn run(args: &AdaptiveArgs, global: &GlobalOpts) -> anyhow::Result<()>
                 .as_deref()
                 .ok_or_else(|| anyhow::anyhow!("--model-path is required for onnx provider."))?;
             let provider = OnnxProvider::new(model_path)?;
-            run_adaptive(&text_str, &provider, llm_client.as_ref(), &config, args, global).await
+            run_adaptive(
+                &text_str,
+                &provider,
+                llm_client.as_ref(),
+                &config,
+                args,
+                global,
+            )
+            .await
         }
         ProviderType::Cloudflare => {
             let (token, account_id, gateway) = resolve_cloudflare_credentials(
@@ -228,7 +252,15 @@ pub async fn run(args: &AdaptiveArgs, global: &GlobalOpts) -> anyhow::Result<()>
             global.detail("[cloudflare] verifying auth token...");
             provider.verify_token().await?;
             global.detail("[cloudflare] token verified");
-            run_adaptive(&text_str, &provider, llm_client.as_ref(), &config, args, global).await
+            run_adaptive(
+                &text_str,
+                &provider,
+                llm_client.as_ref(),
+                &config,
+                args,
+                global,
+            )
+            .await
         }
         ProviderType::Oauth => {
             let creds = resolve_oauth_credentials(
@@ -251,7 +283,15 @@ pub async fn run(args: &AdaptiveArgs, global: &GlobalOpts) -> anyhow::Result<()>
             global.detail("[oauth] acquiring token...");
             provider.verify_credentials().await?;
             global.detail("[oauth] token acquired");
-            run_adaptive(&text_str, &provider, llm_client.as_ref(), &config, args, global).await
+            run_adaptive(
+                &text_str,
+                &provider,
+                llm_client.as_ref(),
+                &config,
+                args,
+                global,
+            )
+            .await
         }
     }
 }

--- a/src/cli/adaptive_cmd.rs
+++ b/src/cli/adaptive_cmd.rs
@@ -1,0 +1,409 @@
+//! Adaptive chunking subcommand.
+
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+use clap::Args;
+
+use cognigraph_chunker::embeddings::cloudflare::{
+    CloudflareProvider, resolve_cloudflare_credentials,
+};
+use cognigraph_chunker::embeddings::oauth::{OAuthProvider, resolve_oauth_credentials};
+use cognigraph_chunker::embeddings::ollama::OllamaProvider;
+use cognigraph_chunker::embeddings::onnx::OnnxProvider;
+use cognigraph_chunker::embeddings::openai::OpenAiProvider;
+use cognigraph_chunker::embeddings::{EmbeddingProvider, ProviderType};
+use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
+use cognigraph_chunker::output::OutputFormat;
+use cognigraph_chunker::semantic::adaptive_chunk::{AdaptiveConfig, adaptive_chunk};
+use cognigraph_chunker::semantic::adaptive_types::AdaptiveResult;
+use cognigraph_chunker::semantic::quality_metrics::MetricWeights;
+
+use super::global_opts::GlobalOpts;
+
+#[derive(Args)]
+pub struct AdaptiveArgs {
+    /// Input file path, or "-" for stdin (default: stdin)
+    #[arg(short, long, default_value = "-")]
+    pub input: String,
+
+    /// Embedding provider
+    #[arg(short, long, value_enum, default_value_t = ProviderType::Ollama)]
+    pub provider: ProviderType,
+
+    /// Model name for embeddings (provider-specific default if omitted)
+    #[arg(short, long)]
+    pub model: Option<String>,
+
+    /// API key (for OpenAI; also reads OPENAI_API_KEY env or .env.openai file)
+    #[arg(long)]
+    pub api_key: Option<String>,
+
+    /// Base URL override for the embedding API
+    #[arg(long)]
+    pub base_url: Option<String>,
+
+    /// Path to ONNX model directory (for onnx provider)
+    #[arg(long)]
+    pub model_path: Option<String>,
+
+    /// Cloudflare auth token
+    #[arg(long)]
+    pub cf_auth_token: Option<String>,
+
+    /// Cloudflare account ID
+    #[arg(long)]
+    pub cf_account_id: Option<String>,
+
+    /// Cloudflare AI Gateway name
+    #[arg(long)]
+    pub cf_ai_gateway: Option<String>,
+
+    /// OAuth token endpoint URL
+    #[arg(long)]
+    pub oauth_token_url: Option<String>,
+
+    /// OAuth client ID
+    #[arg(long)]
+    pub oauth_client_id: Option<String>,
+
+    /// OAuth client secret
+    #[arg(long)]
+    pub oauth_client_secret: Option<String>,
+
+    /// OAuth scope
+    #[arg(long)]
+    pub oauth_scope: Option<String>,
+
+    /// OAuth base URL for the OpenAI-compatible API
+    #[arg(long)]
+    pub oauth_base_url: Option<String>,
+
+    /// Accept invalid TLS certificates (for corporate proxies)
+    #[arg(long)]
+    pub danger_accept_invalid_certs: bool,
+
+    /// LLM model for intent/enriched/topo methods (default: gpt-4.1-mini)
+    #[arg(long)]
+    pub llm_model: Option<String>,
+
+    /// LLM base URL override (default: OpenAI)
+    #[arg(long)]
+    pub llm_base_url: Option<String>,
+
+    /// Comma-separated candidate methods (default: semantic,cognitive; with --api-key: all)
+    #[arg(long)]
+    pub candidates: Option<String>,
+
+    /// Bypass pre-screening and run all listed candidates
+    #[arg(long)]
+    pub force_candidates: bool,
+
+    /// Metric weights as key=value pairs (e.g. "sc=0.3,icc=0.2,dcc=0.2,bi=0.15,rc=0.15")
+    #[arg(long)]
+    pub metric_weights: Option<String>,
+
+    /// Include the full quality report in output
+    #[arg(long)]
+    pub report: bool,
+
+    /// Soft token budget per chunk
+    #[arg(long, default_value_t = 512)]
+    pub soft_budget: usize,
+
+    /// Hard token ceiling per chunk
+    #[arg(long, default_value_t = 768)]
+    pub hard_budget: usize,
+
+    /// Window size for cross-similarity computation (must be odd, >= 3)
+    #[arg(long, default_value_t = 3)]
+    pub sim_window: usize,
+
+    /// Savitzky-Golay smoothing window size (must be odd)
+    #[arg(long, default_value_t = 11)]
+    pub sg_window: usize,
+
+    /// Savitzky-Golay polynomial order
+    #[arg(long, default_value_t = 3)]
+    pub poly_order: usize,
+
+    /// Output format
+    #[arg(short, long, value_enum, default_value_t = OutputFormat::Json)]
+    pub format: OutputFormat,
+}
+
+pub async fn run(args: &AdaptiveArgs, global: &GlobalOpts) -> anyhow::Result<()> {
+    let text = read_input(&args.input, global.max_input_size)?;
+    let text_str = String::from_utf8_lossy(&text);
+
+    global.detail(&format!(
+        "[adaptive] input: {} bytes, provider: {:?}, budget: {}/{}",
+        text.len(),
+        args.provider,
+        args.soft_budget,
+        args.hard_budget,
+    ));
+
+    // Resolve candidates
+    let has_api_key = args.api_key.is_some()
+        || std::env::var("OPENAI_API_KEY").is_ok()
+        || std::fs::read_to_string(".env.openai").is_ok();
+
+    let candidates: Vec<String> = if let Some(ref c) = args.candidates {
+        c.split(',').map(|s| s.trim().to_string()).collect()
+    } else if has_api_key {
+        vec![
+            "semantic".to_string(),
+            "cognitive".to_string(),
+            "intent".to_string(),
+            "enriched".to_string(),
+            "topo".to_string(),
+        ]
+    } else {
+        vec!["semantic".to_string(), "cognitive".to_string()]
+    };
+
+    // Parse metric weights
+    let metric_weights = if let Some(ref w) = args.metric_weights {
+        parse_metric_weights(w)?
+    } else {
+        MetricWeights::default()
+    };
+
+    let config = AdaptiveConfig {
+        candidates,
+        force_candidates: args.force_candidates,
+        soft_budget: args.soft_budget,
+        hard_budget: args.hard_budget,
+        metric_weights,
+        sim_window: args.sim_window,
+        sg_window: args.sg_window,
+        poly_order: args.poly_order,
+    };
+
+    // Build optional LLM client
+    let llm_client = if has_api_key {
+        match LlmConfig::resolve(&args.api_key, &args.llm_base_url, &args.llm_model) {
+            Ok(llm_config) => match CompletionClient::new(llm_config) {
+                Ok(client) => Some(client),
+                Err(e) => {
+                    global.detail(&format!("[adaptive] LLM client init failed: {e}"));
+                    None
+                }
+            },
+            Err(e) => {
+                global.detail(&format!("[adaptive] LLM config resolve failed: {e}"));
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    match args.provider {
+        ProviderType::Ollama => {
+            let provider = OllamaProvider::new(args.base_url.clone(), args.model.clone())?;
+            run_adaptive(&text_str, &provider, llm_client.as_ref(), &config, args, global).await
+        }
+        ProviderType::Openai => {
+            let api_key = resolve_openai_key(&args.api_key)?;
+            let provider = OpenAiProvider::new(api_key, args.base_url.clone(), args.model.clone())?;
+            run_adaptive(&text_str, &provider, llm_client.as_ref(), &config, args, global).await
+        }
+        ProviderType::Onnx => {
+            let model_path = args
+                .model_path
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("--model-path is required for onnx provider."))?;
+            let provider = OnnxProvider::new(model_path)?;
+            run_adaptive(&text_str, &provider, llm_client.as_ref(), &config, args, global).await
+        }
+        ProviderType::Cloudflare => {
+            let (token, account_id, gateway) = resolve_cloudflare_credentials(
+                &args.cf_auth_token,
+                &args.cf_account_id,
+                &args.cf_ai_gateway,
+            )?;
+            let provider = CloudflareProvider::new(token, account_id, args.model.clone(), gateway)?;
+            global.detail("[cloudflare] verifying auth token...");
+            provider.verify_token().await?;
+            global.detail("[cloudflare] token verified");
+            run_adaptive(&text_str, &provider, llm_client.as_ref(), &config, args, global).await
+        }
+        ProviderType::Oauth => {
+            let creds = resolve_oauth_credentials(
+                &args.oauth_token_url,
+                &args.oauth_client_id,
+                &args.oauth_client_secret,
+                &args.oauth_scope,
+                &args.oauth_base_url,
+                &args.model,
+            )?;
+            let provider = OAuthProvider::new(
+                creds.token_url,
+                creds.client_id,
+                creds.client_secret,
+                creds.scope,
+                creds.base_url,
+                creds.model,
+                args.danger_accept_invalid_certs,
+            )?;
+            global.detail("[oauth] acquiring token...");
+            provider.verify_credentials().await?;
+            global.detail("[oauth] token acquired");
+            run_adaptive(&text_str, &provider, llm_client.as_ref(), &config, args, global).await
+        }
+    }
+}
+
+async fn run_adaptive<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: Option<&CompletionClient>,
+    config: &AdaptiveConfig,
+    args: &AdaptiveArgs,
+    global: &GlobalOpts,
+) -> anyhow::Result<()> {
+    let result = adaptive_chunk(text, provider, llm_client, config).await?;
+
+    global.info(&format!(
+        "[adaptive] winner: {} ({} chunks, composite: {:.4})",
+        result.winner,
+        result.count,
+        result
+            .report
+            .candidates
+            .first()
+            .map(|c| c.metrics.composite)
+            .unwrap_or(0.0),
+    ));
+
+    write_output(&result, args);
+    Ok(())
+}
+
+fn write_output(result: &AdaptiveResult, args: &AdaptiveArgs) {
+    match args.format {
+        OutputFormat::Plain => {
+            println!("Winner: {}", result.winner);
+            println!("Chunks: {}", result.count);
+            if args.report {
+                println!("\n--- Quality Report ---");
+                for c in &result.report.candidates {
+                    println!(
+                        "  {}: composite={:.4} sc={:.4} icc={:.4} dcc={:.4} bi={:.4} rc={:.4} ({})",
+                        c.method,
+                        c.metrics.composite,
+                        c.metrics.size_compliance,
+                        c.metrics.intrachunk_cohesion,
+                        c.metrics.contextual_coherence,
+                        c.metrics.block_integrity,
+                        c.metrics.reference_completeness,
+                        c.chunk_count,
+                    );
+                }
+                println!("\n--- Pre-screening ---");
+                for d in &result.report.pre_screening {
+                    let status = if d.included { "OK" } else { "SKIP" };
+                    println!("  [{}] {}: {}", status, d.method, d.reason);
+                }
+            }
+            println!();
+            for chunk in &result.chunks {
+                if let Some(text) = chunk.get("text").and_then(|v| v.as_str()) {
+                    println!("{}", text);
+                    println!();
+                }
+            }
+        }
+        OutputFormat::Json => {
+            if args.report {
+                println!("{}", serde_json::to_string_pretty(&result).unwrap());
+            } else {
+                let output = serde_json::json!({
+                    "winner": result.winner,
+                    "chunks": result.chunks,
+                    "count": result.count,
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            }
+        }
+        OutputFormat::Jsonl => {
+            for chunk in &result.chunks {
+                println!("{}", serde_json::to_string(chunk).unwrap());
+            }
+        }
+    }
+}
+
+fn parse_metric_weights(input: &str) -> anyhow::Result<MetricWeights> {
+    let mut weights = MetricWeights::default();
+    for pair in input.split(',') {
+        let pair = pair.trim();
+        if pair.is_empty() {
+            continue;
+        }
+        let (key, val) = pair
+            .split_once('=')
+            .ok_or_else(|| anyhow::anyhow!("Invalid weight pair: {pair}"))?;
+        let val: f64 = val
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Invalid weight value: {val}"))?;
+        match key.trim() {
+            "sc" | "size_compliance" => weights.sc = val,
+            "icc" | "intrachunk_cohesion" => weights.icc = val,
+            "dcc" | "contextual_coherence" => weights.dcc = val,
+            "bi" | "block_integrity" => weights.bi = val,
+            "rc" | "reference_completeness" => weights.rc = val,
+            other => anyhow::bail!("Unknown metric weight key: {other}"),
+        }
+    }
+    Ok(weights)
+}
+
+fn read_input(input: &str, max_size: usize) -> anyhow::Result<Vec<u8>> {
+    if input == "-" {
+        let mut buf = Vec::new();
+        io::stdin()
+            .take(max_size as u64 + 1)
+            .read_to_end(&mut buf)?;
+        anyhow::ensure!(
+            buf.len() <= max_size,
+            "Stdin input exceeds maximum allowed size ({max_size} bytes)."
+        );
+        Ok(buf)
+    } else {
+        let path = PathBuf::from(input);
+        anyhow::ensure!(path.exists(), "File not found: {}", path.display());
+        let meta = std::fs::metadata(&path)?;
+        anyhow::ensure!(
+            meta.len() <= max_size as u64,
+            "File size ({} bytes) exceeds maximum ({max_size} bytes).",
+            meta.len()
+        );
+        Ok(std::fs::read(&path)?)
+    }
+}
+
+fn resolve_openai_key(flag: &Option<String>) -> anyhow::Result<String> {
+    if let Some(key) = flag {
+        return Ok(key.clone());
+    }
+    if let Ok(key) = std::env::var("OPENAI_API_KEY")
+        && !key.is_empty()
+    {
+        return Ok(key);
+    }
+    if let Ok(content) = std::fs::read_to_string(".env.openai") {
+        for line in content.lines() {
+            let line = line.trim();
+            if let Some(val) = line.strip_prefix("OPENAI_API_KEY=") {
+                let val = val.trim();
+                if !val.is_empty() {
+                    return Ok(val.to_string());
+                }
+            }
+        }
+    }
+    anyhow::bail!("OpenAI API key not found.")
+}

--- a/src/cli/enriched_cmd.rs
+++ b/src/cli/enriched_cmd.rs
@@ -1,0 +1,218 @@
+//! Enriched chunking subcommand.
+
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+use clap::Args;
+use serde::Serialize;
+
+use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
+use cognigraph_chunker::output::OutputFormat;
+use cognigraph_chunker::semantic::enriched_chunk::{EnrichedConfig, enriched_chunk, enriched_chunk_plain};
+use cognigraph_chunker::semantic::enriched_types::{EnrichedResult, TypedEntity};
+
+use super::global_opts::{self, GlobalOpts};
+
+#[derive(Args)]
+pub struct EnrichedArgs {
+    /// Input file path, or "-" for stdin (default: stdin)
+    #[arg(short, long, default_value = "-")]
+    pub input: String,
+
+    /// Output format
+    #[arg(short, long, value_enum, default_value_t = OutputFormat::Plain)]
+    pub format: OutputFormat,
+
+    /// Disable markdown-aware parsing (treat input as plain text)
+    #[arg(long)]
+    pub no_markdown: bool,
+
+    /// Soft token budget per chunk (assembly prefers to stay under this)
+    #[arg(long, default_value_t = 512)]
+    pub soft_budget: usize,
+
+    /// Hard token ceiling per chunk (never exceed unless single block is larger)
+    #[arg(long, default_value_t = 768)]
+    pub hard_budget: usize,
+
+    /// Disable semantic-key recombination
+    #[arg(long)]
+    pub no_recombine: bool,
+
+    /// Disable re-enrichment of merged chunks
+    #[arg(long)]
+    pub no_re_enrich: bool,
+
+    /// LLM model for enrichment (default: gpt-4.1-mini)
+    #[arg(long)]
+    pub enrichment_model: Option<String>,
+
+    /// API key (also reads OPENAI_API_KEY env or .env.openai file)
+    #[arg(long)]
+    pub api_key: Option<String>,
+
+    /// Base URL for the LLM API
+    #[arg(long)]
+    pub llm_base_url: Option<String>,
+}
+
+pub async fn run(args: &EnrichedArgs, global: &GlobalOpts) -> anyhow::Result<()> {
+    let text = read_input(&args.input, global.max_input_size)?;
+    let text_str = String::from_utf8_lossy(&text);
+
+    global.detail(&format!(
+        "[enriched] input: {} bytes, markdown: {}, budget: {}/{}",
+        text.len(),
+        !args.no_markdown,
+        args.soft_budget,
+        args.hard_budget,
+    ));
+
+    // Resolve LLM config
+    let llm_config = LlmConfig::resolve(
+        &args.api_key,
+        &args.llm_base_url,
+        &args.enrichment_model,
+    )?;
+    let llm_client = CompletionClient::new(llm_config)?;
+
+    let config = EnrichedConfig {
+        soft_budget: args.soft_budget,
+        hard_budget: args.hard_budget,
+        recombine: !args.no_recombine,
+        re_enrich: !args.no_re_enrich,
+    };
+
+    let result = if args.no_markdown {
+        enriched_chunk_plain(&text_str, &llm_client, &config).await?
+    } else {
+        enriched_chunk(&text_str, &llm_client, &config).await?
+    };
+
+    global.info(&format!(
+        "[enriched] {} blocks -> {} chunks, {} merges",
+        result.block_count,
+        result.chunks.len(),
+        result.merge_history.len(),
+    ));
+
+    write_enriched_output(&result, args.format);
+
+    // Print stats
+    let stats_chunks: Vec<(String, usize)> = result
+        .chunks
+        .iter()
+        .map(|c| (c.text.clone(), c.offset_start))
+        .collect();
+    global_opts::print_stats(&stats_chunks, global);
+
+    Ok(())
+}
+
+fn write_enriched_output(result: &EnrichedResult, format: OutputFormat) {
+    match format {
+        OutputFormat::Plain => {
+            for (i, chunk) in result.chunks.iter().enumerate() {
+                if i > 0 {
+                    println!();
+                }
+                print!("{}", chunk.text);
+            }
+            println!();
+        }
+        OutputFormat::Json => {
+            let entries: Vec<EnrichedChunkEntry> = result
+                .chunks
+                .iter()
+                .enumerate()
+                .map(|(i, c)| EnrichedChunkEntry {
+                    index: i,
+                    text: &c.text,
+                    offset_start: c.offset_start,
+                    offset_end: c.offset_end,
+                    length: c.text.len(),
+                    token_estimate: c.token_estimate,
+                    title: &c.title,
+                    summary: &c.summary,
+                    keywords: &c.keywords,
+                    typed_entities: &c.typed_entities,
+                    hypothetical_questions: &c.hypothetical_questions,
+                    semantic_keys: &c.semantic_keys,
+                    category: &c.category,
+                    heading_path: &c.heading_path,
+                })
+                .collect();
+
+            let output = serde_json::json!({
+                "chunks": entries,
+                "key_dictionary": result.key_dictionary,
+                "merge_history": result.merge_history,
+                "block_count": result.block_count,
+            });
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+        }
+        OutputFormat::Jsonl => {
+            for (i, chunk) in result.chunks.iter().enumerate() {
+                let entry = EnrichedChunkEntry {
+                    index: i,
+                    text: &chunk.text,
+                    offset_start: chunk.offset_start,
+                    offset_end: chunk.offset_end,
+                    length: chunk.text.len(),
+                    token_estimate: chunk.token_estimate,
+                    title: &chunk.title,
+                    summary: &chunk.summary,
+                    keywords: &chunk.keywords,
+                    typed_entities: &chunk.typed_entities,
+                    hypothetical_questions: &chunk.hypothetical_questions,
+                    semantic_keys: &chunk.semantic_keys,
+                    category: &chunk.category,
+                    heading_path: &chunk.heading_path,
+                };
+                println!("{}", serde_json::to_string(&entry).unwrap());
+            }
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct EnrichedChunkEntry<'a> {
+    index: usize,
+    text: &'a str,
+    offset_start: usize,
+    offset_end: usize,
+    length: usize,
+    token_estimate: usize,
+    title: &'a str,
+    summary: &'a str,
+    keywords: &'a [String],
+    typed_entities: &'a [TypedEntity],
+    hypothetical_questions: &'a [String],
+    semantic_keys: &'a [String],
+    category: &'a str,
+    heading_path: &'a [String],
+}
+
+fn read_input(input: &str, max_size: usize) -> anyhow::Result<Vec<u8>> {
+    if input == "-" {
+        let mut buf = Vec::new();
+        io::stdin()
+            .take(max_size as u64 + 1)
+            .read_to_end(&mut buf)?;
+        anyhow::ensure!(
+            buf.len() <= max_size,
+            "Stdin input exceeds maximum allowed size ({max_size} bytes)."
+        );
+        Ok(buf)
+    } else {
+        let path = PathBuf::from(input);
+        anyhow::ensure!(path.exists(), "File not found: {}", path.display());
+        let meta = std::fs::metadata(&path)?;
+        anyhow::ensure!(
+            meta.len() <= max_size as u64,
+            "File size ({} bytes) exceeds maximum ({max_size} bytes).",
+            meta.len()
+        );
+        Ok(std::fs::read(&path)?)
+    }
+}

--- a/src/cli/enriched_cmd.rs
+++ b/src/cli/enriched_cmd.rs
@@ -8,7 +8,9 @@ use serde::Serialize;
 
 use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
 use cognigraph_chunker::output::OutputFormat;
-use cognigraph_chunker::semantic::enriched_chunk::{EnrichedConfig, enriched_chunk, enriched_chunk_plain};
+use cognigraph_chunker::semantic::enriched_chunk::{
+    EnrichedConfig, enriched_chunk, enriched_chunk_plain,
+};
 use cognigraph_chunker::semantic::enriched_types::{EnrichedResult, TypedEntity};
 
 use super::global_opts::{self, GlobalOpts};
@@ -69,11 +71,7 @@ pub async fn run(args: &EnrichedArgs, global: &GlobalOpts) -> anyhow::Result<()>
     ));
 
     // Resolve LLM config
-    let llm_config = LlmConfig::resolve(
-        &args.api_key,
-        &args.llm_base_url,
-        &args.enrichment_model,
-    )?;
+    let llm_config = LlmConfig::resolve(&args.api_key, &args.llm_base_url, &args.enrichment_model)?;
     let llm_client = CompletionClient::new(llm_config)?;
 
     let config = EnrichedConfig {

--- a/src/cli/intent_cmd.rs
+++ b/src/cli/intent_cmd.rs
@@ -240,11 +240,7 @@ async fn run_pipeline<P: EmbeddingProvider>(
     Ok(())
 }
 
-fn write_intent_output(
-    result: &IntentResult,
-    chunks: &[(String, usize)],
-    format: OutputFormat,
-) {
+fn write_intent_output(result: &IntentResult, chunks: &[(String, usize)], format: OutputFormat) {
     match format {
         OutputFormat::Plain => {
             for (i, (text, _)) in chunks.iter().enumerate() {

--- a/src/cli/intent_cmd.rs
+++ b/src/cli/intent_cmd.rs
@@ -1,0 +1,401 @@
+//! Intent-driven chunking subcommand.
+
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+use clap::Args;
+use serde::Serialize;
+
+use cognigraph_chunker::embeddings::cloudflare::{
+    CloudflareProvider, resolve_cloudflare_credentials,
+};
+use cognigraph_chunker::embeddings::oauth::{OAuthProvider, resolve_oauth_credentials};
+use cognigraph_chunker::embeddings::ollama::OllamaProvider;
+use cognigraph_chunker::embeddings::onnx::OnnxProvider;
+use cognigraph_chunker::embeddings::openai::OpenAiProvider;
+use cognigraph_chunker::embeddings::{EmbeddingProvider, ProviderType};
+use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
+use cognigraph_chunker::output::OutputFormat;
+use cognigraph_chunker::semantic::intent_chunk::{IntentConfig, intent_chunk, intent_chunk_plain};
+use cognigraph_chunker::semantic::intent_types::IntentResult;
+
+use super::global_opts::{self, GlobalOpts};
+use super::merge_opts::{MergeOpts, maybe_merge};
+
+#[derive(Args)]
+pub struct IntentArgs {
+    /// Input file path, or "-" for stdin (default: stdin)
+    #[arg(short, long, default_value = "-")]
+    pub input: String,
+
+    /// Embedding provider
+    #[arg(short, long, value_enum, default_value_t = ProviderType::Ollama)]
+    pub provider: ProviderType,
+
+    /// Model name for embeddings (provider-specific default if omitted)
+    #[arg(short, long)]
+    pub model: Option<String>,
+
+    /// API key (for OpenAI; also reads OPENAI_API_KEY env or .env.openai file)
+    #[arg(long)]
+    pub api_key: Option<String>,
+
+    /// Base URL override for the embedding API
+    #[arg(long)]
+    pub base_url: Option<String>,
+
+    /// Path to ONNX model directory (for onnx provider)
+    #[arg(long)]
+    pub model_path: Option<String>,
+
+    /// Cloudflare auth token
+    #[arg(long)]
+    pub cf_auth_token: Option<String>,
+
+    /// Cloudflare account ID
+    #[arg(long)]
+    pub cf_account_id: Option<String>,
+
+    /// Cloudflare AI Gateway name
+    #[arg(long)]
+    pub cf_ai_gateway: Option<String>,
+
+    /// OAuth token endpoint URL
+    #[arg(long)]
+    pub oauth_token_url: Option<String>,
+
+    /// OAuth client ID
+    #[arg(long)]
+    pub oauth_client_id: Option<String>,
+
+    /// OAuth client secret
+    #[arg(long)]
+    pub oauth_client_secret: Option<String>,
+
+    /// OAuth scope
+    #[arg(long)]
+    pub oauth_scope: Option<String>,
+
+    /// OAuth base URL for the OpenAI-compatible API
+    #[arg(long)]
+    pub oauth_base_url: Option<String>,
+
+    /// Accept invalid TLS certificates (for corporate proxies)
+    #[arg(long)]
+    pub danger_accept_invalid_certs: bool,
+
+    /// Output format
+    #[arg(short, long, value_enum, default_value_t = OutputFormat::Plain)]
+    pub format: OutputFormat,
+
+    /// Disable markdown-aware parsing (treat input as plain text)
+    #[arg(long)]
+    pub no_markdown: bool,
+
+    /// Soft token budget per chunk
+    #[arg(long, default_value_t = 512)]
+    pub soft_budget: usize,
+
+    /// Hard token ceiling per chunk
+    #[arg(long, default_value_t = 768)]
+    pub hard_budget: usize,
+
+    /// LLM model for intent generation
+    #[arg(long, default_value = "gpt-4.1-mini")]
+    pub intent_model: String,
+
+    /// Maximum number of intents to generate
+    #[arg(long, default_value_t = 20)]
+    pub max_intents: usize,
+
+    /// Base URL for the LLM API (defaults to OpenAI)
+    #[arg(long)]
+    pub llm_base_url: Option<String>,
+
+    /// Post-process chunks by merging small ones to fit a token budget
+    #[command(flatten)]
+    pub merge: MergeOpts,
+}
+
+pub async fn run(args: &IntentArgs, global: &GlobalOpts) -> anyhow::Result<()> {
+    let text = read_input(&args.input, global.max_input_size)?;
+    let text_str = String::from_utf8_lossy(&text);
+
+    global.detail(&format!(
+        "[intent] input: {} bytes, provider: {:?}, markdown: {}, budget: {}/{}, max_intents: {}",
+        text.len(),
+        args.provider,
+        !args.no_markdown,
+        args.soft_budget,
+        args.hard_budget,
+        args.max_intents,
+    ));
+
+    // Resolve LLM config for intent generation
+    let llm_config = LlmConfig::resolve(
+        &args.api_key,
+        &args.llm_base_url,
+        &Some(args.intent_model.clone()),
+    )?;
+    let llm_client = CompletionClient::new(llm_config)?;
+
+    let config = IntentConfig {
+        max_intents: args.max_intents,
+        soft_budget: args.soft_budget,
+        hard_budget: args.hard_budget,
+    };
+
+    match args.provider {
+        ProviderType::Ollama => {
+            let provider = OllamaProvider::new(args.base_url.clone(), args.model.clone())?;
+            run_pipeline(&text_str, &provider, &llm_client, &config, args, global).await
+        }
+        ProviderType::Openai => {
+            let api_key = resolve_openai_key(&args.api_key)?;
+            let provider = OpenAiProvider::new(api_key, args.base_url.clone(), args.model.clone())?;
+            run_pipeline(&text_str, &provider, &llm_client, &config, args, global).await
+        }
+        ProviderType::Onnx => {
+            let model_path = args
+                .model_path
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("--model-path is required for onnx provider."))?;
+            let provider = OnnxProvider::new(model_path)?;
+            run_pipeline(&text_str, &provider, &llm_client, &config, args, global).await
+        }
+        ProviderType::Cloudflare => {
+            let (token, account_id, gateway) = resolve_cloudflare_credentials(
+                &args.cf_auth_token,
+                &args.cf_account_id,
+                &args.cf_ai_gateway,
+            )?;
+            let provider = CloudflareProvider::new(token, account_id, args.model.clone(), gateway)?;
+            global.detail("[cloudflare] verifying auth token...");
+            provider.verify_token().await?;
+            global.detail("[cloudflare] token verified");
+            run_pipeline(&text_str, &provider, &llm_client, &config, args, global).await
+        }
+        ProviderType::Oauth => {
+            let creds = resolve_oauth_credentials(
+                &args.oauth_token_url,
+                &args.oauth_client_id,
+                &args.oauth_client_secret,
+                &args.oauth_scope,
+                &args.oauth_base_url,
+                &args.model,
+            )?;
+            let provider = OAuthProvider::new(
+                creds.token_url,
+                creds.client_id,
+                creds.client_secret,
+                creds.scope,
+                creds.base_url,
+                creds.model,
+                args.danger_accept_invalid_certs,
+            )?;
+            global.detail("[oauth] acquiring token...");
+            provider.verify_credentials().await?;
+            global.detail("[oauth] token acquired");
+            run_pipeline(&text_str, &provider, &llm_client, &config, args, global).await
+        }
+    }
+}
+
+async fn run_pipeline<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: &CompletionClient,
+    config: &IntentConfig,
+    args: &IntentArgs,
+    global: &GlobalOpts,
+) -> anyhow::Result<()> {
+    let result = if args.no_markdown {
+        intent_chunk_plain(text, provider, llm_client, config).await?
+    } else {
+        intent_chunk(text, provider, llm_client, config).await?
+    };
+
+    global.info(&format!(
+        "[intent] {} blocks → {} chunks, {} intents, partition_score: {:.4}",
+        result.block_count,
+        result.chunks.len(),
+        result.intents.len(),
+        result.partition_score,
+    ));
+
+    // Optional merge
+    let chunks_as_pairs: Vec<(String, usize)> = result
+        .chunks
+        .iter()
+        .map(|c| (c.text.clone(), c.offset_start))
+        .collect();
+    let final_chunks = maybe_merge(chunks_as_pairs, &args.merge, global);
+
+    // Write output
+    write_intent_output(&result, &final_chunks, args.format);
+
+    // Print stats
+    global_opts::print_stats(&final_chunks, global);
+
+    Ok(())
+}
+
+fn write_intent_output(
+    result: &IntentResult,
+    chunks: &[(String, usize)],
+    format: OutputFormat,
+) {
+    match format {
+        OutputFormat::Plain => {
+            for (i, (text, _)) in chunks.iter().enumerate() {
+                if i > 0 {
+                    println!();
+                }
+                print!("{text}");
+            }
+            println!();
+        }
+        OutputFormat::Json => {
+            let entries: Vec<IntentChunkEntry> = if chunks.len() == result.chunks.len() {
+                // No merge happened: use full metadata
+                result
+                    .chunks
+                    .iter()
+                    .enumerate()
+                    .map(|(i, c)| IntentChunkEntry {
+                        index: i,
+                        text: &c.text,
+                        offset_start: c.offset_start,
+                        offset_end: c.offset_end,
+                        length: c.text.len(),
+                        token_estimate: c.token_estimate,
+                        best_intent: Some(c.best_intent),
+                        alignment_score: Some(c.alignment_score),
+                        heading_path: c.heading_path.clone(),
+                    })
+                    .collect()
+            } else {
+                // Merged: basic metadata only
+                chunks
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (text, offset))| IntentChunkEntry {
+                        index: i,
+                        text,
+                        offset_start: *offset,
+                        offset_end: offset + text.len(),
+                        length: text.len(),
+                        token_estimate: text.split_whitespace().count(),
+                        best_intent: None,
+                        alignment_score: None,
+                        heading_path: vec![],
+                    })
+                    .collect()
+            };
+
+            let output = serde_json::json!({
+                "chunks": entries,
+                "intents": result.intents,
+                "partition_score": result.partition_score,
+                "block_count": result.block_count,
+            });
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+        }
+        OutputFormat::Jsonl => {
+            if chunks.len() == result.chunks.len() {
+                for (i, c) in result.chunks.iter().enumerate() {
+                    let entry = IntentChunkEntry {
+                        index: i,
+                        text: &c.text,
+                        offset_start: c.offset_start,
+                        offset_end: c.offset_end,
+                        length: c.text.len(),
+                        token_estimate: c.token_estimate,
+                        best_intent: Some(c.best_intent),
+                        alignment_score: Some(c.alignment_score),
+                        heading_path: c.heading_path.clone(),
+                    };
+                    println!("{}", serde_json::to_string(&entry).unwrap());
+                }
+            } else {
+                for (i, (text, offset)) in chunks.iter().enumerate() {
+                    let entry = IntentChunkEntry {
+                        index: i,
+                        text,
+                        offset_start: *offset,
+                        offset_end: offset + text.len(),
+                        length: text.len(),
+                        token_estimate: text.split_whitespace().count(),
+                        best_intent: None,
+                        alignment_score: None,
+                        heading_path: vec![],
+                    };
+                    println!("{}", serde_json::to_string(&entry).unwrap());
+                }
+            }
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct IntentChunkEntry<'a> {
+    index: usize,
+    text: &'a str,
+    offset_start: usize,
+    offset_end: usize,
+    length: usize,
+    token_estimate: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    best_intent: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    alignment_score: Option<f64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    heading_path: Vec<String>,
+}
+
+fn read_input(input: &str, max_size: usize) -> anyhow::Result<Vec<u8>> {
+    if input == "-" {
+        let mut buf = Vec::new();
+        io::stdin()
+            .take(max_size as u64 + 1)
+            .read_to_end(&mut buf)?;
+        anyhow::ensure!(
+            buf.len() <= max_size,
+            "Stdin input exceeds maximum allowed size ({max_size} bytes)."
+        );
+        Ok(buf)
+    } else {
+        let path = PathBuf::from(input);
+        anyhow::ensure!(path.exists(), "File not found: {}", path.display());
+        let meta = std::fs::metadata(&path)?;
+        anyhow::ensure!(
+            meta.len() <= max_size as u64,
+            "File size ({} bytes) exceeds maximum ({max_size} bytes).",
+            meta.len()
+        );
+        Ok(std::fs::read(&path)?)
+    }
+}
+
+fn resolve_openai_key(flag: &Option<String>) -> anyhow::Result<String> {
+    if let Some(key) = flag {
+        return Ok(key.clone());
+    }
+    if let Ok(key) = std::env::var("OPENAI_API_KEY")
+        && !key.is_empty()
+    {
+        return Ok(key);
+    }
+    if let Ok(content) = std::fs::read_to_string(".env.openai") {
+        for line in content.lines() {
+            let line = line.trim();
+            if let Some(val) = line.strip_prefix("OPENAI_API_KEY=") {
+                let val = val.trim();
+                if !val.is_empty() {
+                    return Ok(val.to_string());
+                }
+            }
+        }
+    }
+    anyhow::bail!("OpenAI API key not found.")
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,3 +9,4 @@ pub mod merge_opts;
 pub mod semantic_cmd;
 pub mod serve_cmd;
 pub mod split_cmd;
+pub mod topo_cmd;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,6 @@
 //! CLI subcommands.
 
+pub mod adaptive_cmd;
 pub mod chunk_cmd;
 pub mod cognitive_cmd;
 pub mod enriched_cmd;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@
 pub mod chunk_cmd;
 pub mod cognitive_cmd;
 pub mod global_opts;
+pub mod intent_cmd;
 pub mod merge_opts;
 pub mod semantic_cmd;
 pub mod serve_cmd;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod chunk_cmd;
 pub mod cognitive_cmd;
+pub mod enriched_cmd;
 pub mod global_opts;
 pub mod intent_cmd;
 pub mod merge_opts;

--- a/src/cli/topo_cmd.rs
+++ b/src/cli/topo_cmd.rs
@@ -1,0 +1,192 @@
+//! Topology-aware chunking subcommand.
+
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+use clap::Args;
+use serde::Serialize;
+
+use cognigraph_chunker::llm::{CompletionClient, LlmConfig};
+use cognigraph_chunker::output::OutputFormat;
+use cognigraph_chunker::semantic::topo_chunk::{TopoConfig, topo_chunk};
+
+use super::global_opts::{self, GlobalOpts};
+
+#[derive(Args)]
+pub struct TopoArgs {
+    /// Input file path, or "-" for stdin (default: stdin)
+    #[arg(short, long, default_value = "-")]
+    pub input: String,
+
+    /// Output format
+    #[arg(short, long, value_enum, default_value_t = OutputFormat::Plain)]
+    pub format: OutputFormat,
+
+    /// Soft token budget per chunk
+    #[arg(long, default_value_t = 512)]
+    pub soft_budget: usize,
+
+    /// Hard token ceiling per chunk
+    #[arg(long, default_value_t = 768)]
+    pub hard_budget: usize,
+
+    /// Emit the SIR in JSON output
+    #[arg(long)]
+    pub emit_sir: bool,
+
+    /// LLM model for topology agents
+    #[arg(long, default_value = "gpt-4.1-mini")]
+    pub topo_model: String,
+
+    /// API key for the LLM (also reads OPENAI_API_KEY env or .env.openai)
+    #[arg(long)]
+    pub api_key: Option<String>,
+
+    /// Base URL for the LLM API (defaults to OpenAI)
+    #[arg(long)]
+    pub llm_base_url: Option<String>,
+}
+
+pub async fn run(args: &TopoArgs, global: &GlobalOpts) -> anyhow::Result<()> {
+    let text = read_input(&args.input, global.max_input_size)?;
+    let text_str = String::from_utf8_lossy(&text);
+
+    global.detail(&format!(
+        "[topo] input: {} bytes, budget: {}/{}, model: {}",
+        text.len(),
+        args.soft_budget,
+        args.hard_budget,
+        args.topo_model,
+    ));
+
+    // Resolve LLM config
+    let llm_config = LlmConfig::resolve(
+        &args.api_key,
+        &args.llm_base_url,
+        &Some(args.topo_model.clone()),
+    )?;
+    let llm_client = CompletionClient::new(llm_config)?;
+
+    let config = TopoConfig {
+        soft_budget: args.soft_budget,
+        hard_budget: args.hard_budget,
+        emit_sir: args.emit_sir,
+    };
+
+    let result = topo_chunk(&text_str, &llm_client, &config).await?;
+
+    global.info(&format!(
+        "[topo] {} blocks -> {} chunks, {} classifications",
+        result.block_count,
+        result.chunks.len(),
+        result.classifications.len(),
+    ));
+
+    // Write output
+    match args.format {
+        OutputFormat::Plain => {
+            for (i, chunk) in result.chunks.iter().enumerate() {
+                if i > 0 {
+                    println!();
+                }
+                print!("{}", chunk.text);
+            }
+            println!();
+        }
+        OutputFormat::Json => {
+            let entries: Vec<TopoChunkEntry> = result
+                .chunks
+                .iter()
+                .enumerate()
+                .map(|(i, c)| TopoChunkEntry {
+                    index: i,
+                    text: &c.text,
+                    offset_start: c.offset_start,
+                    offset_end: c.offset_end,
+                    length: c.text.len(),
+                    token_estimate: c.token_estimate,
+                    heading_path: c.heading_path.clone(),
+                    section_classification: &c.section_classification,
+                    cross_references: c.cross_references.clone(),
+                })
+                .collect();
+
+            let mut output = serde_json::json!({
+                "chunks": entries,
+                "block_count": result.block_count,
+                "classifications": result.classifications,
+            });
+
+            if args.emit_sir {
+                output["sir"] = serde_json::to_value(&result.sir).unwrap();
+            }
+
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+        }
+        OutputFormat::Jsonl => {
+            for (i, c) in result.chunks.iter().enumerate() {
+                let entry = TopoChunkEntry {
+                    index: i,
+                    text: &c.text,
+                    offset_start: c.offset_start,
+                    offset_end: c.offset_end,
+                    length: c.text.len(),
+                    token_estimate: c.token_estimate,
+                    heading_path: c.heading_path.clone(),
+                    section_classification: &c.section_classification,
+                    cross_references: c.cross_references.clone(),
+                };
+                println!("{}", serde_json::to_string(&entry).unwrap());
+            }
+        }
+    }
+
+    // Print stats
+    let chunks_as_pairs: Vec<(String, usize)> = result
+        .chunks
+        .iter()
+        .map(|c| (c.text.clone(), c.offset_start))
+        .collect();
+    global_opts::print_stats(&chunks_as_pairs, global);
+
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct TopoChunkEntry<'a> {
+    index: usize,
+    text: &'a str,
+    offset_start: usize,
+    offset_end: usize,
+    length: usize,
+    token_estimate: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    heading_path: Vec<String>,
+    section_classification: &'a str,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    cross_references: Vec<usize>,
+}
+
+fn read_input(input: &str, max_size: usize) -> anyhow::Result<Vec<u8>> {
+    if input == "-" {
+        let mut buf = Vec::new();
+        io::stdin()
+            .take(max_size as u64 + 1)
+            .read_to_end(&mut buf)?;
+        anyhow::ensure!(
+            buf.len() <= max_size,
+            "Stdin input exceeds maximum allowed size ({max_size} bytes)."
+        );
+        Ok(buf)
+    } else {
+        let path = PathBuf::from(input);
+        anyhow::ensure!(path.exists(), "File not found: {}", path.display());
+        let meta = std::fs::metadata(&path)?;
+        anyhow::ensure!(
+            meta.len() <= max_size as u64,
+            "File size ({} bytes) exceeds maximum ({max_size} bytes).",
+            meta.len()
+        );
+        Ok(std::fs::read(&path)?)
+    }
+}

--- a/src/llm/enrichment.rs
+++ b/src/llm/enrichment.rs
@@ -1,0 +1,188 @@
+//! LLM-based chunk enrichment.
+//!
+//! Uses structured JSON output from an LLM to extract 7 metadata fields
+//! per chunk: title, summary, keywords, typed_entities, hypothetical_questions,
+//! semantic_keys, and category.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use super::CompletionClient;
+
+/// Response from the enrichment LLM call.
+#[derive(Debug, Deserialize)]
+pub struct EnrichmentResponse {
+    pub title: String,
+    pub summary: String,
+    pub keywords: Vec<String>,
+    pub typed_entities: Vec<TypedEntityLlm>,
+    pub hypothetical_questions: Vec<String>,
+    pub semantic_keys: Vec<String>,
+    pub category: String,
+}
+
+/// Typed entity as returned by the LLM.
+#[derive(Debug, Deserialize)]
+pub struct TypedEntityLlm {
+    pub name: String,
+    pub entity_type: String,
+}
+
+/// Response from the re-enrichment LLM call (title + summary only).
+#[derive(Debug, Deserialize)]
+struct ReEnrichResponse {
+    title: String,
+    summary: String,
+}
+
+const SYSTEM_PROMPT: &str = "\
+You are a document enrichment engine. Given a text chunk from a document, \
+extract exactly 7 metadata fields:
+
+1. title: A concise descriptive title for this chunk (5-10 words).
+2. summary: A 1-2 sentence summary of the chunk's key content.
+3. keywords: 3-8 topical keywords (lowercase, no duplicates).
+4. typed_entities: Named entities with their type (Person, Organization, \
+   Technology, Location, Concept, Event, Product, Metric, Date).
+5. hypothetical_questions: 2-4 questions a user might ask that this chunk answers.
+6. semantic_keys: 2-5 lowercase-hyphenated topic keys (e.g. \"neural-network-training\", \
+   \"api-authentication\"). Reuse existing keys from the dictionary when applicable.
+7. category: Exactly one of: background, methodology, results, discussion, \
+   configuration, reference, definition, procedure, example, other.
+
+Rules:
+- semantic_keys should be specific enough to distinguish topics but general enough \
+  to group related chunks. Prefer reusing keys from the existing dictionary.
+- All keywords and semantic_keys must be lowercase.
+- typed_entities should only include explicitly mentioned entities.";
+
+const RE_ENRICH_SYSTEM_PROMPT: &str = "\
+You are a document enrichment engine. Given a merged text chunk, produce \
+an updated title and summary that accurately reflect the combined content. \
+Keep the title concise (5-10 words) and the summary to 1-2 sentences.";
+
+fn enrichment_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": "Concise descriptive title (5-10 words)"
+            },
+            "summary": {
+                "type": "string",
+                "description": "1-2 sentence summary of key content"
+            },
+            "keywords": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "3-8 topical keywords (lowercase)"
+            },
+            "typed_entities": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "entity_type": { "type": "string" }
+                    },
+                    "required": ["name", "entity_type"],
+                    "additionalProperties": false
+                },
+                "description": "Named entities with type labels"
+            },
+            "hypothetical_questions": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "2-4 questions this chunk answers"
+            },
+            "semantic_keys": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "2-5 lowercase-hyphenated topic keys"
+            },
+            "category": {
+                "type": "string",
+                "description": "One of: background, methodology, results, discussion, configuration, reference, definition, procedure, example, other"
+            }
+        },
+        "required": [
+            "title", "summary", "keywords", "typed_entities",
+            "hypothetical_questions", "semantic_keys", "category"
+        ],
+        "additionalProperties": false
+    })
+}
+
+fn re_enrich_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": "Updated concise title (5-10 words)"
+            },
+            "summary": {
+                "type": "string",
+                "description": "Updated 1-2 sentence summary"
+            }
+        },
+        "required": ["title", "summary"],
+        "additionalProperties": false
+    })
+}
+
+/// Enrich a single chunk with 7 metadata fields via LLM.
+///
+/// The existing key dictionary is included in the prompt so the LLM can
+/// reuse semantic keys for topical coherence across chunks.
+pub async fn enrich_chunk(
+    client: &CompletionClient,
+    text: &str,
+    existing_keys: &HashMap<String, Vec<usize>>,
+) -> Result<EnrichmentResponse> {
+    let mut user_prompt = String::with_capacity(text.len() + 256);
+
+    if !existing_keys.is_empty() {
+        user_prompt.push_str("Existing semantic key dictionary (reuse when applicable):\n");
+        for key in existing_keys.keys() {
+            user_prompt.push_str("- ");
+            user_prompt.push_str(key);
+            user_prompt.push('\n');
+        }
+        user_prompt.push('\n');
+    }
+
+    user_prompt.push_str("Text chunk:\n");
+    user_prompt.push_str(text);
+
+    let response = client
+        .complete_json(SYSTEM_PROMPT, &user_prompt, enrichment_schema())
+        .await
+        .context("Enrichment LLM call failed")?;
+
+    let parsed: EnrichmentResponse = serde_json::from_str(&response).map_err(|e| {
+        anyhow::anyhow!("Failed to parse enrichment response: {e}\nRaw: {response}")
+    })?;
+
+    Ok(parsed)
+}
+
+/// Lightweight re-enrichment after merging: produce updated title + summary.
+pub async fn re_enrich_merged(
+    client: &CompletionClient,
+    text: &str,
+) -> Result<(String, String)> {
+    let response = client
+        .complete_json(RE_ENRICH_SYSTEM_PROMPT, text, re_enrich_schema())
+        .await
+        .context("Re-enrichment LLM call failed")?;
+
+    let parsed: ReEnrichResponse = serde_json::from_str(&response).map_err(|e| {
+        anyhow::anyhow!("Failed to parse re-enrichment response: {e}\nRaw: {response}")
+    })?;
+
+    Ok((parsed.title, parsed.summary))
+}

--- a/src/llm/enrichment.rs
+++ b/src/llm/enrichment.rs
@@ -171,10 +171,7 @@ pub async fn enrich_chunk(
 }
 
 /// Lightweight re-enrichment after merging: produce updated title + summary.
-pub async fn re_enrich_merged(
-    client: &CompletionClient,
-    text: &str,
-) -> Result<(String, String)> {
+pub async fn re_enrich_merged(client: &CompletionClient, text: &str) -> Result<(String, String)> {
     let response = client
         .complete_json(RE_ENRICH_SYSTEM_PROMPT, text, re_enrich_schema())
         .await

--- a/src/llm/intents.rs
+++ b/src/llm/intents.rs
@@ -1,0 +1,101 @@
+//! LLM-based intent generation for intent-driven chunking.
+//!
+//! Uses structured JSON output from an LLM to predict user queries
+//! that the document's content could answer.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use super::CompletionClient;
+use crate::semantic::intent_types::{IntentType, PredictedIntent};
+
+#[derive(Deserialize)]
+struct IntentsResponse {
+    intents: Vec<RawIntent>,
+}
+
+#[derive(Deserialize)]
+struct RawIntent {
+    query: String,
+    intent_type: IntentType,
+}
+
+const SYSTEM_PROMPT: &str = "\
+You are an intent prediction system. Given a document, predict the most likely \
+user queries that this document could answer. Each query should be a realistic \
+question a user might type into a search engine or Q&A system.
+
+Rules:
+- Generate diverse queries covering different aspects of the document
+- Each query should target a specific piece of information or concept
+- Classify each query by intent type:
+  - factual: seeks a specific fact, number, name, or date
+  - procedural: asks how to do something, step-by-step instructions
+  - conceptual: asks for explanation, definition, or understanding
+  - comparative: asks to compare, contrast, or evaluate alternatives
+- Prefer specific queries over vague ones
+- Queries should be self-contained (not reference \"the document\" or \"the text\")";
+
+fn json_schema(max_intents: usize) -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "intents": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "A realistic user query this document could answer"
+                        },
+                        "intent_type": {
+                            "type": "string",
+                            "enum": ["factual", "procedural", "conceptual", "comparative"],
+                            "description": "The type of user intent"
+                        }
+                    },
+                    "required": ["query", "intent_type"],
+                    "additionalProperties": false
+                },
+                "maxItems": max_intents
+            }
+        },
+        "required": ["intents"],
+        "additionalProperties": false
+    })
+}
+
+/// Generate predicted user intents for a document using the LLM.
+pub async fn generate_intents(
+    client: &CompletionClient,
+    text: &str,
+    max_intents: usize,
+) -> Result<Vec<PredictedIntent>> {
+    if text.trim().len() < 20 {
+        return Ok(vec![]);
+    }
+
+    let user_prompt = format!(
+        "Generate up to {max_intents} predicted user queries for this document:\n\n{text}"
+    );
+
+    let response = client
+        .complete_json(SYSTEM_PROMPT, &user_prompt, json_schema(max_intents))
+        .await
+        .context("Intent generation failed")?;
+
+    let parsed: IntentsResponse = serde_json::from_str(&response).map_err(|e| {
+        anyhow::anyhow!("Failed to parse LLM intent response: {e}\nRaw: {response}")
+    })?;
+
+    Ok(parsed
+        .intents
+        .into_iter()
+        .map(|r| PredictedIntent {
+            query: r.query,
+            intent_type: r.intent_type,
+            matched_chunks: vec![],
+        })
+        .collect())
+}

--- a/src/llm/intents.rs
+++ b/src/llm/intents.rs
@@ -76,9 +76,8 @@ pub async fn generate_intents(
         return Ok(vec![]);
     }
 
-    let user_prompt = format!(
-        "Generate up to {max_intents} predicted user queries for this document:\n\n{text}"
-    );
+    let user_prompt =
+        format!("Generate up to {max_intents} predicted user queries for this document:\n\n{text}");
 
     let response = client
         .complete_json(SYSTEM_PROMPT, &user_prompt, json_schema(max_intents))

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -3,6 +3,7 @@
 //! Provides an OpenAI-compatible chat completion client that uses
 //! `response_format: json_schema` for guaranteed structured output.
 
+pub mod enrichment;
 pub mod intents;
 pub mod relations;
 pub mod synopsis;

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -3,6 +3,7 @@
 //! Provides an OpenAI-compatible chat completion client that uses
 //! `response_format: json_schema` for guaranteed structured output.
 
+pub mod intents;
 pub mod relations;
 pub mod synopsis;
 

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -7,6 +7,7 @@ pub mod enrichment;
 pub mod intents;
 pub mod relations;
 pub mod synopsis;
+pub mod topo_agents;
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};

--- a/src/llm/topo_agents.rs
+++ b/src/llm/topo_agents.rs
@@ -104,10 +104,7 @@ pub struct InspectorResponse {
 }
 
 /// Call the Inspector agent to classify SIR sections.
-pub async fn inspect_sir(
-    client: &CompletionClient,
-    sir_json: &str,
-) -> Result<InspectorResponse> {
+pub async fn inspect_sir(client: &CompletionClient, sir_json: &str) -> Result<InspectorResponse> {
     let user_prompt = format!(
         "Analyze this document SIR and classify each section:\n\n{}",
         sir_json
@@ -117,9 +114,8 @@ pub async fn inspect_sir(
         .complete_json(INSPECTOR_SYSTEM, &user_prompt, inspector_schema())
         .await?;
 
-    let parsed: InspectorResponse = serde_json::from_str(&response).map_err(|e| {
-        anyhow::anyhow!("Failed to parse Inspector response: {e}\nRaw: {response}")
-    })?;
+    let parsed: InspectorResponse = serde_json::from_str(&response)
+        .map_err(|e| anyhow::anyhow!("Failed to parse Inspector response: {e}\nRaw: {response}"))?;
 
     Ok(parsed)
 }
@@ -206,9 +202,8 @@ pub async fn refine_partition(
         .complete_json(REFINER_SYSTEM, &user_prompt, refiner_schema())
         .await?;
 
-    let parsed: RefinerResponse = serde_json::from_str(&response).map_err(|e| {
-        anyhow::anyhow!("Failed to parse Refiner response: {e}\nRaw: {response}")
-    })?;
+    let parsed: RefinerResponse = serde_json::from_str(&response)
+        .map_err(|e| anyhow::anyhow!("Failed to parse Refiner response: {e}\nRaw: {response}"))?;
 
     Ok(parsed)
 }

--- a/src/llm/topo_agents.rs
+++ b/src/llm/topo_agents.rs
@@ -1,0 +1,214 @@
+//! LLM agents for topology-aware chunking.
+//!
+//! Two agents work in sequence:
+//! - **Inspector**: classifies SIR sections as atomic / splittable / merge_candidate
+//! - **Refiner**: produces an optimal partition respecting the Inspector's classifications
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use super::CompletionClient;
+
+// ── Inspector Agent ────────────────────────────────────────────────
+
+const INSPECTOR_SYSTEM: &str = "\
+You are a document structure analyst. Given a Structured Intermediate Representation (SIR) \
+of a document, classify each section node by how it should be chunked for retrieval.
+
+For each section, decide:
+- \"atomic\": the section is small enough (roughly under the soft budget) to be kept as one chunk.
+- \"splittable\": the section is too large and must be split into sub-chunks.
+- \"merge_candidate\": the section is very small and should be merged with adjacent sections.
+
+Also identify any cross-section dependencies where splitting would break important context \
+(e.g., a definition in one section referenced in another).
+
+Only classify nodes whose node_type is \"section\". Ignore content_block nodes.";
+
+fn inspector_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "classifications": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "section_id": {
+                            "type": "integer",
+                            "description": "SIR node ID of the section"
+                        },
+                        "class": {
+                            "type": "string",
+                            "enum": ["atomic", "splittable", "merge_candidate"],
+                            "description": "How this section should be treated"
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "Brief reasoning for the classification"
+                        }
+                    },
+                    "required": ["section_id", "class", "reason"],
+                    "additionalProperties": false
+                }
+            },
+            "dependencies": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "from": {
+                            "type": "integer",
+                            "description": "Source section ID"
+                        },
+                        "to": {
+                            "type": "integer",
+                            "description": "Target section ID"
+                        },
+                        "dependency_type": {
+                            "type": "string",
+                            "description": "Type of dependency (e.g., definition_reference, continuation)"
+                        }
+                    },
+                    "required": ["from", "to", "dependency_type"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "required": ["classifications", "dependencies"],
+        "additionalProperties": false
+    })
+}
+
+/// A single section classification from the Inspector.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InspectorClassification {
+    pub section_id: usize,
+    pub class: String,
+    pub reason: String,
+}
+
+/// A cross-section dependency from the Inspector.
+#[derive(Debug, Deserialize)]
+pub struct InspectorDependency {
+    pub from: usize,
+    pub to: usize,
+    pub dependency_type: String,
+}
+
+/// Complete Inspector response.
+#[derive(Debug, Deserialize)]
+pub struct InspectorResponse {
+    pub classifications: Vec<InspectorClassification>,
+    pub dependencies: Vec<InspectorDependency>,
+}
+
+/// Call the Inspector agent to classify SIR sections.
+pub async fn inspect_sir(
+    client: &CompletionClient,
+    sir_json: &str,
+) -> Result<InspectorResponse> {
+    let user_prompt = format!(
+        "Analyze this document SIR and classify each section:\n\n{}",
+        sir_json
+    );
+
+    let response = client
+        .complete_json(INSPECTOR_SYSTEM, &user_prompt, inspector_schema())
+        .await?;
+
+    let parsed: InspectorResponse = serde_json::from_str(&response).map_err(|e| {
+        anyhow::anyhow!("Failed to parse Inspector response: {e}\nRaw: {response}")
+    })?;
+
+    Ok(parsed)
+}
+
+// ── Refiner Agent ──────────────────────────────────────────────────
+
+const REFINER_SYSTEM: &str = "\
+You are a document chunking optimizer. Given section classifications from an Inspector agent, \
+a document SIR, and the full text of splittable sections, produce an optimal partition of \
+the document into chunks.
+
+Rules:
+- Atomic sections become exactly one chunk (use their full block range).
+- Merge candidates should be combined with adjacent atomic or merge_candidate sections.
+- Splittable sections should be divided at natural breakpoints (paragraph boundaries, \
+  sub-heading boundaries) respecting a soft token budget.
+- Each chunk must reference the section IDs it covers and the block range (start, end) \
+  indices from the SIR.
+- Preserve cross-section dependencies: if two sections are linked, prefer keeping them \
+  in the same or adjacent chunks.";
+
+fn refiner_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "partition": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "chunk_id": {
+                            "type": "integer",
+                            "description": "Sequential chunk index"
+                        },
+                        "section_ids": {
+                            "type": "array",
+                            "items": { "type": "integer" },
+                            "description": "SIR section IDs included in this chunk"
+                        },
+                        "block_range": {
+                            "type": "array",
+                            "items": { "type": "integer" },
+                            "description": "Two-element array [start, end) of block indices"
+                        }
+                    },
+                    "required": ["chunk_id", "section_ids", "block_range"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "required": ["partition"],
+        "additionalProperties": false
+    })
+}
+
+/// A single chunk in the Refiner's partition.
+#[derive(Debug, Deserialize)]
+pub struct RefinerChunk {
+    pub chunk_id: usize,
+    pub section_ids: Vec<usize>,
+    pub block_range: Vec<usize>,
+}
+
+/// Complete Refiner response.
+#[derive(Debug, Deserialize)]
+pub struct RefinerResponse {
+    pub partition: Vec<RefinerChunk>,
+}
+
+/// Call the Refiner agent to produce a chunk partition.
+pub async fn refine_partition(
+    client: &CompletionClient,
+    inspector_json: &str,
+    sir_json: &str,
+    section_texts: &str,
+) -> Result<RefinerResponse> {
+    let user_prompt = format!(
+        "Inspector classifications:\n{inspector_json}\n\n\
+         Document SIR:\n{sir_json}\n\n\
+         Splittable section texts:\n{section_texts}"
+    );
+
+    let response = client
+        .complete_json(REFINER_SYSTEM, &user_prompt, refiner_schema())
+        .await?;
+
+    let parsed: RefinerResponse = serde_json::from_str(&response).map_err(|e| {
+        anyhow::anyhow!("Failed to parse Refiner response: {e}\nRaw: {response}")
+    })?;
+
+    Ok(parsed)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,16 @@ EXAMPLES:
 ")]
     Topo(Box<cli::topo_cmd::TopoArgs>),
 
+    /// Adaptive chunking: evaluates multiple methods and picks the best
+    #[command(after_help = "\
+EXAMPLES:
+  cognigraph-chunker adaptive -i doc.md
+  cognigraph-chunker adaptive -i doc.md -p openai --report
+  cognigraph-chunker adaptive -i doc.md --candidates semantic,cognitive,intent
+  cognigraph-chunker adaptive -i doc.md --force-candidates --metric-weights sc=0.3,icc=0.2
+")]
+    Adaptive(Box<cli::adaptive_cmd::AdaptiveArgs>),
+
     /// Start REST API server
     #[command(after_help = "\
 EXAMPLES:
@@ -152,6 +162,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Intent(args) => cli::intent_cmd::run(args, &cli.global).await,
         Commands::Enriched(args) => cli::enriched_cmd::run(args, &cli.global).await,
         Commands::Topo(args) => cli::topo_cmd::run(args, &cli.global).await,
+        Commands::Adaptive(args) => cli::adaptive_cmd::run(args, &cli.global).await,
         Commands::Serve(args) => cli::serve_cmd::run(args).await,
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,17 @@ EXAMPLES:
 ")]
     Intent(Box<cli::intent_cmd::IntentArgs>),
 
+    /// Enriched chunking with LLM metadata and semantic-key recombination
+    #[command(after_help = "\
+EXAMPLES:
+  cognigraph-chunker enriched -i doc.md
+  cognigraph-chunker enriched -i doc.md -f json
+  cognigraph-chunker enriched -i doc.md --soft-budget 256 --hard-budget 512
+  cognigraph-chunker enriched -i doc.md --no-recombine --no-re-enrich
+  cognigraph-chunker enriched -i doc.md --enrichment-model gpt-4.1-mini
+")]
+    Enriched(Box<cli::enriched_cmd::EnrichedArgs>),
+
     /// Start REST API server
     #[command(after_help = "\
 EXAMPLES:
@@ -129,6 +140,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Semantic(args) => cli::semantic_cmd::run(args, &cli.global).await,
         Commands::Cognitive(args) => cli::cognitive_cmd::run(args, &cli.global).await,
         Commands::Intent(args) => cli::intent_cmd::run(args, &cli.global).await,
+        Commands::Enriched(args) => cli::enriched_cmd::run(args, &cli.global).await,
         Commands::Serve(args) => cli::serve_cmd::run(args).await,
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,16 @@ EXAMPLES:
 ")]
     Cognitive(Box<cli::cognitive_cmd::CognitiveArgs>),
 
+    /// Intent-driven chunking using LLM-predicted queries and DP alignment
+    #[command(after_help = "\
+EXAMPLES:
+  cognigraph-chunker intent -i doc.md -p openai
+  cognigraph-chunker intent -i doc.md -p openai -f json
+  cognigraph-chunker intent -i doc.md --max-intents 10 --soft-budget 256
+  cognigraph-chunker intent -i doc.md --intent-model gpt-4.1-mini
+")]
+    Intent(Box<cli::intent_cmd::IntentArgs>),
+
     /// Start REST API server
     #[command(after_help = "\
 EXAMPLES:
@@ -118,6 +128,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Split(args) => cli::split_cmd::run(args, &cli.global),
         Commands::Semantic(args) => cli::semantic_cmd::run(args, &cli.global).await,
         Commands::Cognitive(args) => cli::cognitive_cmd::run(args, &cli.global).await,
+        Commands::Intent(args) => cli::intent_cmd::run(args, &cli.global).await,
         Commands::Serve(args) => cli::serve_cmd::run(args).await,
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,16 @@ EXAMPLES:
 ")]
     Enriched(Box<cli::enriched_cmd::EnrichedArgs>),
 
+    /// Topology-aware chunking using SIR and dual LLM agents
+    #[command(after_help = "\
+EXAMPLES:
+  cognigraph-chunker topo -i doc.md
+  cognigraph-chunker topo -i doc.md -f json --emit-sir
+  cognigraph-chunker topo -i doc.md --soft-budget 256 --hard-budget 512
+  cognigraph-chunker topo -i doc.md --topo-model gpt-4.1-mini
+")]
+    Topo(Box<cli::topo_cmd::TopoArgs>),
+
     /// Start REST API server
     #[command(after_help = "\
 EXAMPLES:
@@ -141,6 +151,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Cognitive(args) => cli::cognitive_cmd::run(args, &cli.global).await,
         Commands::Intent(args) => cli::intent_cmd::run(args, &cli.global).await,
         Commands::Enriched(args) => cli::enriched_cmd::run(args, &cli.global).await,
+        Commands::Topo(args) => cli::topo_cmd::run(args, &cli.global).await,
         Commands::Serve(args) => cli::serve_cmd::run(args).await,
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();

--- a/src/semantic/adaptive_chunk.rs
+++ b/src/semantic/adaptive_chunk.rs
@@ -1,0 +1,551 @@
+//! Adaptive chunking meta-router.
+//!
+//! Evaluates multiple candidate chunking methods via intrinsic quality metrics
+//! and returns the winner's chunks along with a comparative report.
+
+use anyhow::Result;
+
+use crate::embeddings::EmbeddingProvider;
+use crate::llm::CompletionClient;
+
+use super::adaptive_types::{
+    AdaptiveReport, AdaptiveResult, CandidateScore, ScreeningDecision,
+};
+use super::blocks::{BlockKind, split_blocks};
+use super::cognitive_types::{CognitiveConfig, CognitiveWeights};
+use super::enriched_chunk::{EnrichedConfig, enriched_chunk};
+use super::intent_chunk::{IntentConfig, intent_chunk};
+use super::quality_metrics::{ChunkForEval, MetricConfig, MetricWeights, evaluate_chunks};
+use super::topo_chunk::{TopoConfig, topo_chunk};
+use super::{SemanticConfig, cognitive_chunk, semantic_chunk};
+
+/// Configuration for the adaptive chunking router.
+#[derive(Debug, Clone)]
+pub struct AdaptiveConfig {
+    /// Method names to try (e.g. ["semantic", "cognitive", "intent"]).
+    pub candidates: Vec<String>,
+    /// If true, bypass pre-screening heuristics and run all listed candidates.
+    pub force_candidates: bool,
+    /// Soft token budget per chunk.
+    pub soft_budget: usize,
+    /// Hard token ceiling per chunk.
+    pub hard_budget: usize,
+    /// Weights for the quality metric composite score.
+    pub metric_weights: MetricWeights,
+    /// Window size for cross-similarity (semantic/cognitive).
+    pub sim_window: usize,
+    /// Savitzky-Golay smoothing window (semantic/cognitive).
+    pub sg_window: usize,
+    /// Savitzky-Golay polynomial order (semantic/cognitive).
+    pub poly_order: usize,
+}
+
+impl Default for AdaptiveConfig {
+    fn default() -> Self {
+        Self {
+            candidates: vec!["semantic".to_string(), "cognitive".to_string()],
+            force_candidates: false,
+            soft_budget: 512,
+            hard_budget: 768,
+            metric_weights: MetricWeights::default(),
+            sim_window: 3,
+            sg_window: 11,
+            poly_order: 3,
+        }
+    }
+}
+
+/// Estimate token count using whitespace splitting.
+fn token_estimate(text: &str) -> usize {
+    text.split_whitespace().count()
+}
+
+/// Count distinct heading levels in a document (using split_blocks).
+fn count_heading_levels(text: &str) -> usize {
+    let blocks = split_blocks(text);
+    let mut levels = std::collections::HashSet::new();
+    for block in &blocks {
+        if block.kind == BlockKind::Heading {
+            let trimmed = block.text.trim();
+            let level = trimmed.chars().take_while(|&c| c == '#').count();
+            if level > 0 {
+                levels.insert(level);
+            }
+        }
+    }
+    levels.len()
+}
+
+/// Check whether a document has any markdown structure (headings, lists, tables, code blocks).
+fn has_markdown_structure(text: &str) -> bool {
+    let blocks = split_blocks(text);
+    blocks.iter().any(|b| {
+        matches!(
+            b.kind,
+            BlockKind::Heading | BlockKind::Table | BlockKind::CodeBlock | BlockKind::List
+        )
+    })
+}
+
+/// Pre-screen candidates based on document characteristics.
+///
+/// Returns a list of screening decisions and the filtered candidate names.
+pub fn pre_screen(
+    text: &str,
+    candidates: &[String],
+    force: bool,
+) -> (Vec<ScreeningDecision>, Vec<String>) {
+    let doc_tokens = token_estimate(text);
+    let heading_levels = count_heading_levels(text);
+    let has_structure = has_markdown_structure(text);
+
+    let mut decisions = Vec::new();
+    let mut included = Vec::new();
+
+    for method in candidates {
+        let (include, reason) = if force {
+            (true, "force_candidates enabled".to_string())
+        } else {
+            match method.as_str() {
+                "semantic" => (true, "always included".to_string()),
+                "cognitive" => (true, "always included".to_string()),
+                "topo" => {
+                    if heading_levels < 2 {
+                        (
+                            false,
+                            format!(
+                                "skipped: document has {} heading level(s), topo needs >= 2",
+                                heading_levels
+                            ),
+                        )
+                    } else {
+                        (true, format!("{heading_levels} heading levels detected"))
+                    }
+                }
+                "intent" => {
+                    if doc_tokens < 500 {
+                        (
+                            false,
+                            format!(
+                                "skipped: document has {doc_tokens} tokens, intent needs >= 500"
+                            ),
+                        )
+                    } else {
+                        (true, format!("{doc_tokens} tokens, sufficient for intent"))
+                    }
+                }
+                "enriched" => {
+                    if !has_structure && doc_tokens < 1000 {
+                        (
+                            false,
+                            format!(
+                                "skipped: no markdown structure and {doc_tokens} < 1000 tokens"
+                            ),
+                        )
+                    } else {
+                        (true, "document has structure or sufficient length".to_string())
+                    }
+                }
+                other => (false, format!("unknown method: {other}")),
+            }
+        };
+
+        decisions.push(ScreeningDecision {
+            method: method.clone(),
+            included: include,
+            reason,
+        });
+
+        if include {
+            included.push(method.clone());
+        }
+    }
+
+    (decisions, included)
+}
+
+/// Run the adaptive chunking meta-router.
+///
+/// Evaluates each screened candidate method, scores their output using quality
+/// metrics, and returns the winner's chunks with a full comparison report.
+///
+/// If `llm_client` is None, LLM-based methods (intent, enriched, topo) are
+/// automatically excluded even if listed in `config.candidates`.
+pub async fn adaptive_chunk<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: Option<&CompletionClient>,
+    config: &AdaptiveConfig,
+) -> Result<AdaptiveResult> {
+    // Filter out LLM methods if no client is available
+    let effective_candidates: Vec<String> = config
+        .candidates
+        .iter()
+        .filter(|m| {
+            if llm_client.is_none() {
+                !matches!(m.as_str(), "intent" | "enriched" | "topo")
+            } else {
+                true
+            }
+        })
+        .cloned()
+        .collect();
+
+    // Pre-screen
+    let (screening_decisions, screened) =
+        pre_screen(text, &effective_candidates, config.force_candidates);
+
+    if screened.is_empty() {
+        anyhow::bail!("No candidate methods passed pre-screening");
+    }
+
+    let metric_config = MetricConfig {
+        soft_budget: config.soft_budget,
+        hard_budget: config.hard_budget,
+        weights: config.metric_weights.clone(),
+    };
+
+    // Run each candidate and evaluate
+    let mut scored: Vec<(String, Vec<ChunkForEval>, Vec<serde_json::Value>, CandidateScore)> =
+        Vec::new();
+
+    for method in &screened {
+        let result = run_candidate(text, method, provider, llm_client, config).await;
+
+        match result {
+            Ok((evals, json_chunks)) => {
+                let total_tokens: usize = evals.iter().map(|c| token_estimate(&c.text)).sum();
+                let chunk_count = evals.len();
+
+                match evaluate_chunks(text, &evals, provider, &metric_config).await {
+                    Ok(metrics) => {
+                        scored.push((
+                            method.clone(),
+                            evals,
+                            json_chunks,
+                            CandidateScore {
+                                method: method.clone(),
+                                metrics,
+                                chunk_count,
+                                total_tokens,
+                            },
+                        ));
+                    }
+                    Err(e) => {
+                        eprintln!("[adaptive] evaluation failed for {method}: {e}");
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("[adaptive] candidate {method} failed: {e}");
+            }
+        }
+    }
+
+    if scored.is_empty() {
+        anyhow::bail!("All candidate methods failed");
+    }
+
+    // Pick winner: highest composite score, ties broken by fewer chunks
+    scored.sort_by(|a, b| {
+        b.3.metrics
+            .composite
+            .partial_cmp(&a.3.metrics.composite)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.3.chunk_count.cmp(&b.3.chunk_count))
+    });
+
+    let (winner_name, _evals, winner_chunks, _winner_score) = scored.remove(0);
+
+    // Build candidate scores list (winner + others)
+    let mut candidate_scores: Vec<CandidateScore> = Vec::new();
+    candidate_scores.push(_winner_score);
+    for (_, _, _, score) in scored {
+        candidate_scores.push(score);
+    }
+
+    let count = winner_chunks.len();
+
+    Ok(AdaptiveResult {
+        winner: winner_name,
+        chunks: winner_chunks,
+        report: AdaptiveReport {
+            candidates: candidate_scores,
+            pre_screening: screening_decisions,
+            metric_weights: config.metric_weights.clone(),
+        },
+        count,
+    })
+}
+
+/// Run a single candidate method and return its chunks as both evaluation structs and JSON.
+async fn run_candidate<P: EmbeddingProvider>(
+    text: &str,
+    method: &str,
+    provider: &P,
+    llm_client: Option<&CompletionClient>,
+    config: &AdaptiveConfig,
+) -> Result<(Vec<ChunkForEval>, Vec<serde_json::Value>)> {
+    match method {
+        "semantic" => {
+            let sem_config = SemanticConfig {
+                sim_window: config.sim_window,
+                sg_window: config.sg_window,
+                poly_order: config.poly_order,
+                ..SemanticConfig::default()
+            };
+            let result = semantic_chunk(text, provider, &sem_config).await?;
+            let evals: Vec<ChunkForEval> = result
+                .chunks
+                .iter()
+                .map(|(chunk_text, offset)| ChunkForEval {
+                    text: chunk_text.clone(),
+                    offset_start: *offset,
+                    offset_end: offset + chunk_text.len(),
+                })
+                .collect();
+            let json_chunks: Vec<serde_json::Value> = result
+                .chunks
+                .iter()
+                .enumerate()
+                .map(|(i, (chunk_text, offset))| {
+                    serde_json::json!({
+                        "index": i,
+                        "text": chunk_text,
+                        "offset": offset,
+                        "length": chunk_text.len(),
+                    })
+                })
+                .collect();
+            Ok((evals, json_chunks))
+        }
+        "cognitive" => {
+            let cog_config = CognitiveConfig {
+                weights: CognitiveWeights::default(),
+                soft_budget: config.soft_budget,
+                hard_budget: config.hard_budget,
+                sim_window: config.sim_window,
+                sg_window: config.sg_window,
+                poly_order: config.poly_order,
+                max_blocks: 10_000,
+                emit_signals: false,
+                language: None,
+            };
+            let result = cognitive_chunk(text, provider, &cog_config).await?;
+            let evals: Vec<ChunkForEval> = result
+                .chunks
+                .iter()
+                .map(|c| ChunkForEval {
+                    text: c.text.clone(),
+                    offset_start: c.offset_start,
+                    offset_end: c.offset_end,
+                })
+                .collect();
+            let json_chunks: Vec<serde_json::Value> = result
+                .chunks
+                .iter()
+                .enumerate()
+                .map(|(i, c)| {
+                    serde_json::json!({
+                        "index": i,
+                        "text": c.text,
+                        "offset_start": c.offset_start,
+                        "offset_end": c.offset_end,
+                        "token_estimate": c.token_estimate,
+                        "heading_path": c.heading_path,
+                        "dominant_entities": c.dominant_entities,
+                    })
+                })
+                .collect();
+            Ok((evals, json_chunks))
+        }
+        "intent" => {
+            let client = llm_client
+                .ok_or_else(|| anyhow::anyhow!("intent method requires LLM client"))?;
+            let intent_config = IntentConfig {
+                soft_budget: config.soft_budget,
+                hard_budget: config.hard_budget,
+                ..IntentConfig::default()
+            };
+            let result = intent_chunk(text, provider, client, &intent_config).await?;
+            let evals: Vec<ChunkForEval> = result
+                .chunks
+                .iter()
+                .map(|c| ChunkForEval {
+                    text: c.text.clone(),
+                    offset_start: c.offset_start,
+                    offset_end: c.offset_end,
+                })
+                .collect();
+            let json_chunks: Vec<serde_json::Value> = result
+                .chunks
+                .iter()
+                .map(|c| serde_json::to_value(c).unwrap_or_default())
+                .collect();
+            Ok((evals, json_chunks))
+        }
+        "enriched" => {
+            let client = llm_client
+                .ok_or_else(|| anyhow::anyhow!("enriched method requires LLM client"))?;
+            let enriched_config = EnrichedConfig {
+                soft_budget: config.soft_budget,
+                hard_budget: config.hard_budget,
+                ..EnrichedConfig::default()
+            };
+            let result = enriched_chunk(text, client, &enriched_config).await?;
+            let evals: Vec<ChunkForEval> = result
+                .chunks
+                .iter()
+                .map(|c| ChunkForEval {
+                    text: c.text.clone(),
+                    offset_start: c.offset_start,
+                    offset_end: c.offset_end,
+                })
+                .collect();
+            let json_chunks: Vec<serde_json::Value> = result
+                .chunks
+                .iter()
+                .map(|c| serde_json::to_value(c).unwrap_or_default())
+                .collect();
+            Ok((evals, json_chunks))
+        }
+        "topo" => {
+            let client = llm_client
+                .ok_or_else(|| anyhow::anyhow!("topo method requires LLM client"))?;
+            let topo_config = TopoConfig {
+                soft_budget: config.soft_budget,
+                hard_budget: config.hard_budget,
+                ..TopoConfig::default()
+            };
+            let result = topo_chunk(text, client, &topo_config).await?;
+            let evals: Vec<ChunkForEval> = result
+                .chunks
+                .iter()
+                .map(|c| ChunkForEval {
+                    text: c.text.clone(),
+                    offset_start: c.offset_start,
+                    offset_end: c.offset_end,
+                })
+                .collect();
+            let json_chunks: Vec<serde_json::Value> = result
+                .chunks
+                .iter()
+                .map(|c| serde_json::to_value(c).unwrap_or_default())
+                .collect();
+            Ok((evals, json_chunks))
+        }
+        other => anyhow::bail!("unknown chunking method: {other}"),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pre_screening_flat_doc() {
+        // A document with no headings should skip topo
+        let doc = "Just a flat paragraph without any headings.\nAnother sentence here.\nMore content follows.";
+        let candidates = vec![
+            "semantic".to_string(),
+            "cognitive".to_string(),
+            "topo".to_string(),
+        ];
+
+        let (decisions, included) = pre_screen(doc, &candidates, false);
+
+        // topo should be excluded
+        assert!(!included.contains(&"topo".to_string()));
+        assert!(included.contains(&"semantic".to_string()));
+        assert!(included.contains(&"cognitive".to_string()));
+
+        // Verify the screening decision for topo says excluded
+        let topo_decision = decisions.iter().find(|d| d.method == "topo").unwrap();
+        assert!(!topo_decision.included);
+        assert!(topo_decision.reason.contains("heading level"));
+    }
+
+    #[test]
+    fn test_pre_screening_short_doc() {
+        // A document < 500 tokens should skip intent
+        let doc = "Short document. Only a few words here.";
+        let candidates = vec![
+            "semantic".to_string(),
+            "cognitive".to_string(),
+            "intent".to_string(),
+        ];
+
+        let (decisions, included) = pre_screen(doc, &candidates, false);
+
+        assert!(!included.contains(&"intent".to_string()));
+        assert!(included.contains(&"semantic".to_string()));
+
+        let intent_decision = decisions.iter().find(|d| d.method == "intent").unwrap();
+        assert!(!intent_decision.included);
+        assert!(intent_decision.reason.contains("tokens"));
+    }
+
+    #[test]
+    fn test_pre_screening_force_candidates() {
+        // With force_candidates, everything should be included
+        let doc = "Short doc.";
+        let candidates = vec![
+            "semantic".to_string(),
+            "cognitive".to_string(),
+            "intent".to_string(),
+            "topo".to_string(),
+            "enriched".to_string(),
+        ];
+
+        let (_decisions, included) = pre_screen(doc, &candidates, true);
+
+        assert_eq!(included.len(), 5);
+        for method in &candidates {
+            assert!(included.contains(method), "Expected {method} to be included");
+        }
+    }
+
+    #[test]
+    fn test_pre_screening_enriched_no_structure_short() {
+        // A short document with no markdown structure should skip enriched
+        let doc = "Plain text with no markdown. Just sentences.";
+        let candidates = vec!["enriched".to_string()];
+
+        let (_decisions, included) = pre_screen(doc, &candidates, false);
+        assert!(!included.contains(&"enriched".to_string()));
+    }
+
+    #[test]
+    fn test_pre_screening_enriched_with_structure() {
+        // A document with markdown structure should include enriched
+        let doc = "# Heading\n\nSome content here.\n\n## Subheading\n\nMore content.";
+        let candidates = vec!["enriched".to_string()];
+
+        let (_decisions, included) = pre_screen(doc, &candidates, false);
+        assert!(included.contains(&"enriched".to_string()));
+    }
+
+    #[test]
+    fn test_pre_screening_topo_with_multiple_levels() {
+        // A document with >= 2 heading levels should include topo
+        let doc = "# Top\n\nIntro.\n\n## Sub\n\nContent.";
+        let candidates = vec!["topo".to_string()];
+
+        let (_decisions, included) = pre_screen(doc, &candidates, false);
+        assert!(included.contains(&"topo".to_string()));
+    }
+
+    #[test]
+    fn test_count_heading_levels() {
+        let doc = "# H1\n\nText.\n\n## H2\n\nMore.\n\n### H3\n\nDeep.";
+        assert_eq!(count_heading_levels(doc), 3);
+
+        let flat = "No headings at all.";
+        assert_eq!(count_heading_levels(flat), 0);
+
+        let single = "# Only one level\n\nContent.";
+        assert_eq!(count_heading_levels(single), 1);
+    }
+}

--- a/src/semantic/adaptive_chunk.rs
+++ b/src/semantic/adaptive_chunk.rs
@@ -8,9 +8,7 @@ use anyhow::Result;
 use crate::embeddings::EmbeddingProvider;
 use crate::llm::CompletionClient;
 
-use super::adaptive_types::{
-    AdaptiveReport, AdaptiveResult, CandidateScore, ScreeningDecision,
-};
+use super::adaptive_types::{AdaptiveReport, AdaptiveResult, CandidateScore, ScreeningDecision};
 use super::blocks::{BlockKind, split_blocks};
 use super::cognitive_types::{CognitiveConfig, CognitiveWeights};
 use super::enriched_chunk::{EnrichedConfig, enriched_chunk};
@@ -143,7 +141,10 @@ pub fn pre_screen(
                             ),
                         )
                     } else {
-                        (true, "document has structure or sufficient length".to_string())
+                        (
+                            true,
+                            "document has structure or sufficient length".to_string(),
+                        )
                     }
                 }
                 other => (false, format!("unknown method: {other}")),
@@ -206,8 +207,12 @@ pub async fn adaptive_chunk<P: EmbeddingProvider>(
     };
 
     // Run each candidate and evaluate
-    let mut scored: Vec<(String, Vec<ChunkForEval>, Vec<serde_json::Value>, CandidateScore)> =
-        Vec::new();
+    let mut scored: Vec<(
+        String,
+        Vec<ChunkForEval>,
+        Vec<serde_json::Value>,
+        CandidateScore,
+    )> = Vec::new();
 
     for method in &screened {
         let result = run_candidate(text, method, provider, llm_client, config).await;
@@ -360,8 +365,8 @@ async fn run_candidate<P: EmbeddingProvider>(
             Ok((evals, json_chunks))
         }
         "intent" => {
-            let client = llm_client
-                .ok_or_else(|| anyhow::anyhow!("intent method requires LLM client"))?;
+            let client =
+                llm_client.ok_or_else(|| anyhow::anyhow!("intent method requires LLM client"))?;
             let intent_config = IntentConfig {
                 soft_budget: config.soft_budget,
                 hard_budget: config.hard_budget,
@@ -385,8 +390,8 @@ async fn run_candidate<P: EmbeddingProvider>(
             Ok((evals, json_chunks))
         }
         "enriched" => {
-            let client = llm_client
-                .ok_or_else(|| anyhow::anyhow!("enriched method requires LLM client"))?;
+            let client =
+                llm_client.ok_or_else(|| anyhow::anyhow!("enriched method requires LLM client"))?;
             let enriched_config = EnrichedConfig {
                 soft_budget: config.soft_budget,
                 hard_budget: config.hard_budget,
@@ -410,8 +415,8 @@ async fn run_candidate<P: EmbeddingProvider>(
             Ok((evals, json_chunks))
         }
         "topo" => {
-            let client = llm_client
-                .ok_or_else(|| anyhow::anyhow!("topo method requires LLM client"))?;
+            let client =
+                llm_client.ok_or_else(|| anyhow::anyhow!("topo method requires LLM client"))?;
             let topo_config = TopoConfig {
                 soft_budget: config.soft_budget,
                 hard_budget: config.hard_budget,
@@ -503,7 +508,10 @@ mod tests {
 
         assert_eq!(included.len(), 5);
         for method in &candidates {
-            assert!(included.contains(method), "Expected {method} to be included");
+            assert!(
+                included.contains(method),
+                "Expected {method} to be included"
+            );
         }
     }
 

--- a/src/semantic/adaptive_types.rs
+++ b/src/semantic/adaptive_types.rs
@@ -1,0 +1,53 @@
+//! Data types for adaptive chunking.
+
+use serde::Serialize;
+
+use super::quality_metrics::{MetricWeights, QualityMetrics};
+
+/// Result of the adaptive chunking meta-router.
+#[derive(Debug, Serialize)]
+pub struct AdaptiveResult {
+    /// Name of the winning method.
+    pub winner: String,
+    /// The winner's chunks serialized as JSON values (polymorphic across method types).
+    pub chunks: Vec<serde_json::Value>,
+    /// Quality evaluation report for all candidates.
+    pub report: AdaptiveReport,
+    /// Number of chunks produced by the winner.
+    pub count: usize,
+}
+
+/// Full report of the adaptive selection process.
+#[derive(Debug, Serialize)]
+pub struct AdaptiveReport {
+    /// Scores for each candidate that was evaluated.
+    pub candidates: Vec<CandidateScore>,
+    /// Pre-screening decisions for all considered methods.
+    pub pre_screening: Vec<ScreeningDecision>,
+    /// Metric weights used for composite scoring.
+    pub metric_weights: MetricWeights,
+}
+
+/// Quality metrics and metadata for a single candidate method.
+#[derive(Debug, Serialize)]
+pub struct CandidateScore {
+    /// Method name (e.g. "semantic", "cognitive").
+    pub method: String,
+    /// Quality metrics computed by evaluate_chunks.
+    pub metrics: QualityMetrics,
+    /// Number of chunks produced.
+    pub chunk_count: usize,
+    /// Sum of estimated token counts across all chunks.
+    pub total_tokens: usize,
+}
+
+/// Pre-screening decision for a candidate method.
+#[derive(Debug, Serialize)]
+pub struct ScreeningDecision {
+    /// Method name.
+    pub method: String,
+    /// Whether the method was included as a candidate.
+    pub included: bool,
+    /// Human-readable reason for inclusion or exclusion.
+    pub reason: String,
+}

--- a/src/semantic/blocks.rs
+++ b/src/semantic/blocks.rs
@@ -10,7 +10,7 @@ use pulldown_cmark::{Event, Options, Parser, Tag};
 use super::sentence::split_sentences;
 
 /// The kind of block extracted from the document.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum BlockKind {
     /// A sentence extracted from a paragraph.
     Sentence,

--- a/src/semantic/enriched_chunk.rs
+++ b/src/semantic/enriched_chunk.rs
@@ -317,7 +317,7 @@ fn recombine_by_keys(
 
     // Sort by adjacency (adjacent pairs first) then by index
     merge_pairs.sort_by_key(|&(_, a, b)| {
-        let distance = if b > a { b - a } else { a - b };
+        let distance = b.abs_diff(a);
         (distance, a)
     });
 

--- a/src/semantic/enriched_chunk.rs
+++ b/src/semantic/enriched_chunk.rs
@@ -1,0 +1,502 @@
+//! Enriched chunking pipeline.
+//!
+//! Structure-preserving chunking + single-call LLM enrichment with
+//! 7 metadata fields + semantic-key recombination.
+//!
+//! Pipeline:
+//! 1. Parse blocks (markdown or plain)
+//! 2. Compute heading paths
+//! 3. Greedy initial grouping respecting budgets and atomic blocks
+//! 4. LLM enrichment per chunk (rolling key dictionary)
+//! 5. Semantic-key recombination (merge chunks sharing identical keys)
+//! 6. Optional re-enrichment of merged chunks
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+use crate::llm::CompletionClient;
+use crate::llm::enrichment::{self, EnrichmentResponse};
+
+use super::blocks::{Block, BlockKind, split_blocks};
+use super::enriched_types::{EnrichedChunk, EnrichedResult, MergeRecord, TypedEntity};
+use super::enrichment::heading_context::compute_heading_paths;
+use super::sentence::split_sentences;
+
+/// Configuration for the enriched chunking pipeline.
+#[derive(Debug, Clone)]
+pub struct EnrichedConfig {
+    /// Soft token budget: prefer to stay under this per chunk.
+    pub soft_budget: usize,
+    /// Hard token ceiling: never exceed unless a single block is larger.
+    pub hard_budget: usize,
+    /// Whether to perform semantic-key recombination.
+    pub recombine: bool,
+    /// Whether to re-enrich merged chunks (update title + summary).
+    pub re_enrich: bool,
+}
+
+impl Default for EnrichedConfig {
+    fn default() -> Self {
+        Self {
+            soft_budget: 512,
+            hard_budget: 768,
+            recombine: true,
+            re_enrich: true,
+        }
+    }
+}
+
+/// Run the enriched chunking pipeline with markdown-aware parsing.
+pub async fn enriched_chunk(
+    text: &str,
+    llm_client: &CompletionClient,
+    config: &EnrichedConfig,
+) -> Result<EnrichedResult> {
+    let blocks = split_blocks(text);
+    run_enriched_pipeline(blocks, llm_client, config).await
+}
+
+/// Run the enriched chunking pipeline with plain text (no markdown).
+pub async fn enriched_chunk_plain(
+    text: &str,
+    llm_client: &CompletionClient,
+    config: &EnrichedConfig,
+) -> Result<EnrichedResult> {
+    let sentences = split_sentences(text);
+    let blocks: Vec<Block<'_>> = sentences
+        .into_iter()
+        .map(|s| Block {
+            text: s.text,
+            offset: s.offset,
+            kind: BlockKind::Sentence,
+        })
+        .collect();
+    run_enriched_pipeline(blocks, llm_client, config).await
+}
+
+/// Estimate token count using whitespace splitting (fast approximation).
+pub fn estimate_tokens(text: &str) -> usize {
+    text.split_whitespace().count()
+}
+
+/// A group of blocks forming an initial chunk before LLM enrichment.
+struct InitialGroup {
+    text: String,
+    offset_start: usize,
+    offset_end: usize,
+    token_estimate: usize,
+    heading_path: Vec<String>,
+}
+
+/// Greedy initial grouping of blocks into chunks.
+///
+/// Rules:
+/// - Headings start a new chunk.
+/// - Atomic blocks (Table, CodeBlock, List, BlockQuote) are kept whole.
+/// - Accumulate blocks until the soft budget is reached.
+fn initial_grouping(
+    blocks: &[Block<'_>],
+    heading_paths: &[Vec<String>],
+    soft_budget: usize,
+) -> Vec<InitialGroup> {
+    if blocks.is_empty() {
+        return vec![];
+    }
+
+    let mut groups: Vec<InitialGroup> = Vec::new();
+    let mut current_text = String::new();
+    let mut current_start = blocks[0].offset;
+    let mut current_tokens: usize = 0;
+    let mut current_heading = if !heading_paths.is_empty() {
+        heading_paths[0].clone()
+    } else {
+        vec![]
+    };
+
+    for (i, block) in blocks.iter().enumerate() {
+        let block_tokens = estimate_tokens(block.text);
+        let is_heading = block.kind == BlockKind::Heading;
+        let is_atomic = matches!(
+            block.kind,
+            BlockKind::Table | BlockKind::CodeBlock | BlockKind::List | BlockKind::BlockQuote
+        );
+        let heading_path = if i < heading_paths.len() {
+            &heading_paths[i]
+        } else {
+            &current_heading
+        };
+
+        // Start new chunk on heading
+        if is_heading && !current_text.is_empty() {
+            let offset_end = current_start + current_text.len();
+            groups.push(InitialGroup {
+                text: std::mem::take(&mut current_text),
+                offset_start: current_start,
+                offset_end,
+                token_estimate: current_tokens,
+                heading_path: current_heading.clone(),
+            });
+            current_start = block.offset;
+            current_tokens = 0;
+        }
+
+        // Start new chunk if adding this block would exceed soft budget
+        // (unless current chunk is empty — always take at least one block)
+        if !current_text.is_empty()
+            && current_tokens + block_tokens > soft_budget
+            && (is_atomic || block_tokens > 0)
+        {
+            let offset_end = current_start + current_text.len();
+            groups.push(InitialGroup {
+                text: std::mem::take(&mut current_text),
+                offset_start: current_start,
+                offset_end,
+                token_estimate: current_tokens,
+                heading_path: current_heading.clone(),
+            });
+            current_start = block.offset;
+            current_tokens = 0;
+        }
+
+        current_text.push_str(block.text);
+        current_tokens += block_tokens;
+        current_heading = heading_path.clone();
+    }
+
+    // Flush remaining
+    if !current_text.is_empty() {
+        let offset_end = current_start + current_text.len();
+        groups.push(InitialGroup {
+            text: current_text,
+            offset_start: current_start,
+            offset_end,
+            token_estimate: current_tokens,
+            heading_path: current_heading,
+        });
+    }
+
+    groups
+}
+
+async fn run_enriched_pipeline(
+    blocks: Vec<Block<'_>>,
+    llm_client: &CompletionClient,
+    config: &EnrichedConfig,
+) -> Result<EnrichedResult> {
+    let block_count = blocks.len();
+
+    if blocks.is_empty() {
+        return Ok(EnrichedResult {
+            chunks: vec![],
+            key_dictionary: HashMap::new(),
+            merge_history: vec![],
+            block_count: 0,
+        });
+    }
+
+    // Step 1-2: Compute heading paths
+    let (heading_paths, _heading_terms) = compute_heading_paths(&blocks);
+
+    // Step 3: Initial grouping
+    let groups = initial_grouping(&blocks, &heading_paths, config.soft_budget);
+
+    // Step 4: Enrich each group via LLM
+    let mut key_dictionary: HashMap<String, Vec<usize>> = HashMap::new();
+    let mut chunks: Vec<EnrichedChunk> = Vec::with_capacity(groups.len());
+
+    for (idx, group) in groups.iter().enumerate() {
+        let enrichment = enrichment::enrich_chunk(llm_client, &group.text, &key_dictionary).await?;
+
+        // Update key dictionary
+        for key in &enrichment.semantic_keys {
+            let normalized = key.to_lowercase();
+            key_dictionary
+                .entry(normalized.clone())
+                .or_default()
+                .push(idx);
+        }
+
+        chunks.push(enrichment_to_chunk(group, enrichment));
+    }
+
+    // Step 5: Semantic-key recombination
+    let mut merge_history: Vec<MergeRecord> = Vec::new();
+
+    if config.recombine {
+        let (merged_chunks, merges) =
+            recombine_by_keys(&chunks, &key_dictionary, config.hard_budget);
+        chunks = merged_chunks;
+        merge_history = merges;
+
+        // Rebuild key dictionary after merges
+        key_dictionary.clear();
+        for (idx, chunk) in chunks.iter().enumerate() {
+            for key in &chunk.semantic_keys {
+                key_dictionary.entry(key.clone()).or_default().push(idx);
+            }
+        }
+
+        // Step 6: Re-enrich merged chunks
+        if config.re_enrich && !merge_history.is_empty() {
+            for record in &merge_history {
+                let chunk_idx = record.result_chunk;
+                if chunk_idx < chunks.len() {
+                    match enrichment::re_enrich_merged(llm_client, &chunks[chunk_idx].text).await {
+                        Ok((title, summary)) => {
+                            chunks[chunk_idx].title = title;
+                            chunks[chunk_idx].summary = summary;
+                        }
+                        Err(_) => {
+                            // Keep original title/summary on failure
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(EnrichedResult {
+        chunks,
+        key_dictionary,
+        merge_history,
+        block_count,
+    })
+}
+
+/// Convert an LLM enrichment response into an EnrichedChunk.
+fn enrichment_to_chunk(group: &InitialGroup, resp: EnrichmentResponse) -> EnrichedChunk {
+    EnrichedChunk {
+        text: group.text.clone(),
+        offset_start: group.offset_start,
+        offset_end: group.offset_end,
+        token_estimate: group.token_estimate,
+        title: resp.title,
+        summary: resp.summary,
+        keywords: resp.keywords,
+        typed_entities: resp
+            .typed_entities
+            .into_iter()
+            .map(|e| TypedEntity {
+                name: e.name,
+                entity_type: e.entity_type,
+            })
+            .collect(),
+        hypothetical_questions: resp.hypothetical_questions,
+        semantic_keys: resp
+            .semantic_keys
+            .into_iter()
+            .map(|k| k.to_lowercase())
+            .collect(),
+        category: resp.category,
+        heading_path: group.heading_path.clone(),
+    }
+}
+
+/// Recombine chunks that share identical semantic keys using bin-packing.
+///
+/// Prioritizes adjacent chunks. Respects hard_budget limit.
+fn recombine_by_keys(
+    chunks: &[EnrichedChunk],
+    key_dictionary: &HashMap<String, Vec<usize>>,
+    hard_budget: usize,
+) -> (Vec<EnrichedChunk>, Vec<MergeRecord>) {
+    let mut merged_into: Vec<Option<usize>> = vec![None; chunks.len()];
+    let mut merge_records: Vec<MergeRecord> = Vec::new();
+
+    // Find merge candidates: keys that appear in exactly 2 chunks
+    let mut merge_pairs: Vec<(String, usize, usize)> = Vec::new();
+    for (key, indices) in key_dictionary {
+        if indices.len() == 2 {
+            let a = indices[0];
+            let b = indices[1];
+            // Prefer adjacent pairs
+            merge_pairs.push((key.clone(), a, b));
+        }
+    }
+
+    // Sort by adjacency (adjacent pairs first) then by index
+    merge_pairs.sort_by_key(|&(_, a, b)| {
+        let distance = if b > a { b - a } else { a - b };
+        (distance, a)
+    });
+
+    for (key, a, b) in &merge_pairs {
+        let a = *a;
+        let b = *b;
+
+        // Skip if either chunk is already merged
+        if merged_into[a].is_some() || merged_into[b].is_some() {
+            continue;
+        }
+
+        // Check budget
+        let combined_tokens = chunks[a].token_estimate + chunks[b].token_estimate;
+        if combined_tokens > hard_budget {
+            continue;
+        }
+
+        // Merge b into a
+        merged_into[b] = Some(a);
+        merge_records.push(MergeRecord {
+            result_chunk: a, // Will be remapped after building result
+            source_chunks: vec![a, b],
+            shared_key: key.clone(),
+        });
+    }
+
+    // Build result
+    let mut result: Vec<EnrichedChunk> = Vec::new();
+    let mut old_to_new: Vec<Option<usize>> = vec![None; chunks.len()];
+
+    for (i, chunk) in chunks.iter().enumerate() {
+        if merged_into[i].is_some() {
+            continue; // This chunk was merged into another
+        }
+
+        let new_idx = result.len();
+        old_to_new[i] = Some(new_idx);
+
+        // Collect all chunks merged into this one
+        let merge_sources: Vec<usize> = (0..chunks.len())
+            .filter(|&j| merged_into[j] == Some(i))
+            .collect();
+
+        if merge_sources.is_empty() {
+            result.push(chunk.clone());
+        } else {
+            // Merge texts and metadata
+            let mut merged = chunk.clone();
+            for &src_idx in &merge_sources {
+                let src = &chunks[src_idx];
+                merged.text.push('\n');
+                merged.text.push_str(&src.text);
+                merged.token_estimate += src.token_estimate;
+                merged.offset_end = merged.offset_end.max(src.offset_end);
+
+                // Union keywords
+                for kw in &src.keywords {
+                    if !merged.keywords.contains(kw) {
+                        merged.keywords.push(kw.clone());
+                    }
+                }
+                // Union entities
+                for ent in &src.typed_entities {
+                    if !merged.typed_entities.iter().any(|e| e.name == ent.name) {
+                        merged.typed_entities.push(ent.clone());
+                    }
+                }
+                // Union questions
+                for q in &src.hypothetical_questions {
+                    if !merged.hypothetical_questions.contains(q) {
+                        merged.hypothetical_questions.push(q.clone());
+                    }
+                }
+                // Union semantic keys
+                for sk in &src.semantic_keys {
+                    if !merged.semantic_keys.contains(sk) {
+                        merged.semantic_keys.push(sk.clone());
+                    }
+                }
+            }
+            result.push(merged);
+        }
+    }
+
+    // Remap merge record indices
+    for record in &mut merge_records {
+        if let Some(new_idx) = old_to_new[record.result_chunk] {
+            record.result_chunk = new_idx;
+        }
+    }
+
+    (result, merge_records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_estimate_tokens() {
+        assert_eq!(estimate_tokens("hello world"), 2);
+        assert_eq!(estimate_tokens("one two three four"), 4);
+        assert_eq!(estimate_tokens(""), 0);
+        assert_eq!(estimate_tokens("  spaces  between  "), 2);
+    }
+
+    #[test]
+    fn test_initial_grouping_respects_budget() {
+        // Create blocks that should be split across multiple groups
+        let blocks = vec![
+            Block {
+                text: "Word ".repeat(100).leak(),
+                offset: 0,
+                kind: BlockKind::Sentence,
+            },
+            Block {
+                text: "More ".repeat(100).leak(),
+                offset: 500,
+                kind: BlockKind::Sentence,
+            },
+            Block {
+                text: "Extra ".repeat(100).leak(),
+                offset: 1000,
+                kind: BlockKind::Sentence,
+            },
+        ];
+        let heading_paths = vec![vec![]; 3];
+
+        let groups = initial_grouping(&blocks, &heading_paths, 150);
+
+        // Each block has 100 tokens, budget is 150, so:
+        // - Block 0 (100 tokens) fits alone
+        // - Block 1 (100 tokens) would exceed 150 with block 0, so starts new group
+        // - Block 2 (100 tokens) would exceed 150 with block 1, so starts new group
+        assert!(
+            groups.len() >= 2,
+            "Expected at least 2 groups, got {}",
+            groups.len()
+        );
+        for group in &groups {
+            assert!(
+                group.token_estimate <= 200,
+                "Group token estimate {} exceeds expected limit",
+                group.token_estimate
+            );
+        }
+    }
+
+    #[test]
+    fn test_initial_grouping_heading_starts_new() {
+        let blocks = vec![
+            Block {
+                text: "Intro text.",
+                offset: 0,
+                kind: BlockKind::Sentence,
+            },
+            Block {
+                text: "# Section A\n",
+                offset: 12,
+                kind: BlockKind::Heading,
+            },
+            Block {
+                text: "Section content.",
+                offset: 25,
+                kind: BlockKind::Sentence,
+            },
+        ];
+        let heading_paths = vec![
+            vec![],
+            vec!["Section A".to_string()],
+            vec!["Section A".to_string()],
+        ];
+
+        let groups = initial_grouping(&blocks, &heading_paths, 1000);
+
+        // The heading should force a split even though budget allows all together
+        assert_eq!(groups.len(), 2, "Heading should start a new group");
+        assert!(groups[0].text.contains("Intro"));
+        assert!(groups[1].text.contains("# Section A"));
+    }
+}

--- a/src/semantic/enriched_types.rs
+++ b/src/semantic/enriched_types.rs
@@ -1,0 +1,46 @@
+//! Data types for enriched chunking.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// An entity with its type label (e.g. "OpenAI" / "Organization").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TypedEntity {
+    pub name: String,
+    pub entity_type: String,
+}
+
+/// Record of a merge operation during semantic-key recombination.
+#[derive(Debug, Clone, Serialize)]
+pub struct MergeRecord {
+    pub result_chunk: usize,
+    pub source_chunks: Vec<usize>,
+    pub shared_key: String,
+}
+
+/// A single enriched chunk with full LLM-generated metadata.
+#[derive(Debug, Clone, Serialize)]
+pub struct EnrichedChunk {
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+    pub token_estimate: usize,
+    pub title: String,
+    pub summary: String,
+    pub keywords: Vec<String>,
+    pub typed_entities: Vec<TypedEntity>,
+    pub hypothetical_questions: Vec<String>,
+    pub semantic_keys: Vec<String>,
+    pub category: String,
+    pub heading_path: Vec<String>,
+}
+
+/// Result of the enriched chunking pipeline.
+#[derive(Debug)]
+pub struct EnrichedResult {
+    pub chunks: Vec<EnrichedChunk>,
+    pub key_dictionary: HashMap<String, Vec<usize>>,
+    pub merge_history: Vec<MergeRecord>,
+    pub block_count: usize,
+}

--- a/src/semantic/intent_chunk.rs
+++ b/src/semantic/intent_chunk.rs
@@ -86,14 +86,17 @@ async fn run_intent_pipeline<P: EmbeddingProvider>(
 
     // Step 2: Generate intents via LLM
     let full_text: String = blocks.iter().map(|b| b.text).collect::<Vec<_>>().join(" ");
-    let intents = crate::llm::intents::generate_intents(llm_client, &full_text, config.max_intents)
-        .await?;
+    let intents =
+        crate::llm::intents::generate_intents(llm_client, &full_text, config.max_intents).await?;
 
     if intents.is_empty() {
         // If LLM returns no intents, produce a single chunk
         let text_joined: String = blocks.iter().map(|b| b.text).collect::<Vec<_>>().join("");
         let offset_start = blocks[0].offset;
-        let offset_end = blocks.last().map(|b| b.offset + b.text.len()).unwrap_or(offset_start);
+        let offset_end = blocks
+            .last()
+            .map(|b| b.offset + b.text.len())
+            .unwrap_or(offset_start);
         return Ok(IntentResult {
             chunks: vec![IntentChunk {
                 text: text_joined.clone(),
@@ -151,14 +154,12 @@ async fn run_intent_pipeline<P: EmbeddingProvider>(
     let n = blocks.len();
     let min_blocks = 1;
     // Max blocks per chunk: enough to fill hard_budget
-    let max_blocks_per_chunk = n.min(
-        if config.hard_budget > 0 {
-            // Estimate: average ~4 tokens per block minimum, so hard_budget/1 is upper bound
-            config.hard_budget.max(1)
-        } else {
-            n
-        },
-    );
+    let max_blocks_per_chunk = n.min(if config.hard_budget > 0 {
+        // Estimate: average ~4 tokens per block minimum, so hard_budget/1 is upper bound
+        config.hard_budget.max(1)
+    } else {
+        n
+    });
 
     // dp[i] represents the best partition score for blocks 0..i
     // dp[0] = 0.0 (empty prefix)
@@ -254,10 +255,7 @@ async fn run_intent_pipeline<P: EmbeddingProvider>(
                 .push(chunk_idx);
         }
 
-        let heading_path = heading_paths
-            .get(start)
-            .cloned()
-            .unwrap_or_default();
+        let heading_path = heading_paths.get(start).cloned().unwrap_or_default();
 
         chunks.push(IntentChunk {
             text: chunk_text,
@@ -395,7 +393,11 @@ mod tests {
 
     #[test]
     fn test_centroid_multiple() {
-        let embeddings = vec![vec![1.0, 0.0, 0.0], vec![0.0, 1.0, 0.0], vec![0.0, 0.0, 1.0]];
+        let embeddings = vec![
+            vec![1.0, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0],
+            vec![0.0, 0.0, 1.0],
+        ];
         let c = centroid(&embeddings);
         let expected = vec![1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0];
         for (a, b) in c.iter().zip(expected.iter()) {

--- a/src/semantic/intent_chunk.rs
+++ b/src/semantic/intent_chunk.rs
@@ -399,7 +399,7 @@ mod tests {
             vec![0.0, 0.0, 1.0],
         ];
         let c = centroid(&embeddings);
-        let expected = vec![1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0];
+        let expected = [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0];
         for (a, b) in c.iter().zip(expected.iter()) {
             assert!((a - b).abs() < 1e-10);
         }

--- a/src/semantic/intent_chunk.rs
+++ b/src/semantic/intent_chunk.rs
@@ -122,6 +122,10 @@ async fn run_intent_pipeline<P: EmbeddingProvider>(
         );
     }
 
+    if block_embeddings.is_empty() {
+        bail!("No block embeddings returned");
+    }
+
     let dim = block_embeddings[0].len();
     if dim == 0 {
         bail!("Embedding dimension is 0");
@@ -167,10 +171,9 @@ async fn run_intent_pipeline<P: EmbeddingProvider>(
         let mut best_j = 0;
 
         // Try all chunk sizes ending at block i-1
-        let mut chunk_tokens_sum = 0;
         for size in 1..=i.min(max_blocks_per_chunk) {
             let j = i - size; // chunk spans blocks j..i
-            chunk_tokens_sum += block_tokens[i - size];
+            let chunk_tokens_sum: usize = block_tokens[j..i].iter().sum();
 
             // Skip if previous prefix is unreachable
             if dp_score[j] == f64::NEG_INFINITY {
@@ -237,6 +240,7 @@ async fn run_intent_pipeline<P: EmbeddingProvider>(
             .collect::<Vec<_>>()
             .join("");
         let offset_start = blocks[start].offset;
+        // Offsets are byte-based (from pulldown_cmark AST), matching split_blocks() convention.
         let offset_end = blocks[end - 1].offset + blocks[end - 1].text.len();
         let token_est = estimate_tokens(&chunk_text);
         let chunk_centroid = centroid(&block_embeddings[start..end]);

--- a/src/semantic/intent_chunk.rs
+++ b/src/semantic/intent_chunk.rs
@@ -1,0 +1,429 @@
+//! Intent-driven chunking pipeline with dynamic programming alignment.
+//!
+//! Pipeline: blocks → LLM intent generation → embed blocks + intents
+//!   → DP alignment → optimal chunk partition
+
+use anyhow::{Result, bail};
+
+use crate::embeddings::EmbeddingProvider;
+use crate::llm::CompletionClient;
+
+use super::blocks::{Block, BlockKind, split_blocks};
+use super::enrichment::heading_context::compute_heading_paths;
+use super::intent_types::{IntentChunk, IntentResult};
+use super::sentence::split_sentences;
+
+/// Configuration for intent-driven chunking.
+#[derive(Debug, Clone)]
+pub struct IntentConfig {
+    /// Maximum number of intents to generate via LLM.
+    pub max_intents: usize,
+    /// Soft token budget per chunk (DP prefers chunks near this size).
+    pub soft_budget: usize,
+    /// Hard token ceiling per chunk (never exceed unless single block is larger).
+    pub hard_budget: usize,
+}
+
+impl Default for IntentConfig {
+    fn default() -> Self {
+        Self {
+            max_intents: 20,
+            soft_budget: 512,
+            hard_budget: 768,
+        }
+    }
+}
+
+/// Run intent-driven chunking with markdown-aware block splitting.
+pub async fn intent_chunk<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: &CompletionClient,
+    config: &IntentConfig,
+) -> Result<IntentResult> {
+    let blocks = split_blocks(text);
+    run_intent_pipeline(blocks, provider, llm_client, config).await
+}
+
+/// Run intent-driven chunking with plain text (no markdown parsing).
+pub async fn intent_chunk_plain<P: EmbeddingProvider>(
+    text: &str,
+    provider: &P,
+    llm_client: &CompletionClient,
+    config: &IntentConfig,
+) -> Result<IntentResult> {
+    let sentences = split_sentences(text);
+    let blocks: Vec<Block<'_>> = sentences
+        .into_iter()
+        .map(|s| Block {
+            text: s.text,
+            offset: s.offset,
+            kind: BlockKind::Sentence,
+        })
+        .collect();
+    run_intent_pipeline(blocks, provider, llm_client, config).await
+}
+
+async fn run_intent_pipeline<P: EmbeddingProvider>(
+    blocks: Vec<Block<'_>>,
+    provider: &P,
+    llm_client: &CompletionClient,
+    config: &IntentConfig,
+) -> Result<IntentResult> {
+    let block_count = blocks.len();
+
+    if blocks.is_empty() {
+        return Ok(IntentResult {
+            chunks: vec![],
+            intents: vec![],
+            partition_score: 0.0,
+            block_count: 0,
+        });
+    }
+
+    // Step 1: Compute heading paths
+    let (heading_paths, _heading_terms) = compute_heading_paths(&blocks);
+
+    // Step 2: Generate intents via LLM
+    let full_text: String = blocks.iter().map(|b| b.text).collect::<Vec<_>>().join(" ");
+    let intents = crate::llm::intents::generate_intents(llm_client, &full_text, config.max_intents)
+        .await?;
+
+    if intents.is_empty() {
+        // If LLM returns no intents, produce a single chunk
+        let text_joined: String = blocks.iter().map(|b| b.text).collect::<Vec<_>>().join("");
+        let offset_start = blocks[0].offset;
+        let offset_end = blocks.last().map(|b| b.offset + b.text.len()).unwrap_or(offset_start);
+        return Ok(IntentResult {
+            chunks: vec![IntentChunk {
+                text: text_joined.clone(),
+                offset_start,
+                offset_end,
+                token_estimate: estimate_tokens(&text_joined),
+                best_intent: 0,
+                alignment_score: 0.0,
+                heading_path: heading_paths.first().cloned().unwrap_or_default(),
+            }],
+            intents: vec![],
+            partition_score: 0.0,
+            block_count,
+        });
+    }
+
+    // Step 3: Embed all blocks
+    let block_texts: Vec<&str> = blocks.iter().map(|b| b.text).collect();
+    let block_embeddings = provider.embed(&block_texts).await?;
+
+    if block_embeddings.len() != blocks.len() {
+        bail!(
+            "Provider returned {} embeddings for {} blocks",
+            block_embeddings.len(),
+            blocks.len()
+        );
+    }
+
+    let dim = block_embeddings[0].len();
+    if dim == 0 {
+        bail!("Embedding dimension is 0");
+    }
+
+    // Step 4: Embed all intents
+    let intent_queries: Vec<&str> = intents.iter().map(|i| i.query.as_str()).collect();
+    let intent_embeddings = provider.embed(&intent_queries).await?;
+
+    if intent_embeddings.len() != intents.len() {
+        bail!(
+            "Provider returned {} embeddings for {} intents",
+            intent_embeddings.len(),
+            intents.len()
+        );
+    }
+
+    // Step 5: Compute token estimates per block
+    let block_tokens: Vec<usize> = blocks.iter().map(|b| estimate_tokens(b.text)).collect();
+
+    // Step 6: DP alignment
+    // dp[i] = (best_score, backtrack_idx) for optimal partition of blocks 0..i
+    let n = blocks.len();
+    let min_blocks = 1;
+    // Max blocks per chunk: enough to fill hard_budget
+    let max_blocks_per_chunk = n.min(
+        if config.hard_budget > 0 {
+            // Estimate: average ~4 tokens per block minimum, so hard_budget/1 is upper bound
+            config.hard_budget.max(1)
+        } else {
+            n
+        },
+    );
+
+    // dp[i] represents the best partition score for blocks 0..i
+    // dp[0] = 0.0 (empty prefix)
+    let mut dp_score: Vec<f64> = vec![f64::NEG_INFINITY; n + 1];
+    let mut dp_back: Vec<usize> = vec![0; n + 1];
+    dp_score[0] = 0.0;
+
+    for i in 1..=n {
+        let mut best_score = f64::NEG_INFINITY;
+        let mut best_j = 0;
+
+        // Try all chunk sizes ending at block i-1
+        let mut chunk_tokens_sum = 0;
+        for size in 1..=i.min(max_blocks_per_chunk) {
+            let j = i - size; // chunk spans blocks j..i
+            chunk_tokens_sum += block_tokens[i - size];
+
+            // Skip if previous prefix is unreachable
+            if dp_score[j] == f64::NEG_INFINITY {
+                continue;
+            }
+
+            // Skip if over hard budget (unless this is a single block)
+            if chunk_tokens_sum > config.hard_budget && size > 1 {
+                break; // Larger chunks will only be bigger
+            }
+
+            if size < min_blocks {
+                continue;
+            }
+
+            // Compute chunk centroid embedding
+            let chunk_centroid = centroid(&block_embeddings[j..i]);
+
+            // Find best intent alignment
+            let (_best_intent_idx, alignment) =
+                best_intent_match(&chunk_centroid, &intent_embeddings);
+
+            // Budget penalty: penalize chunks far from soft_budget
+            let budget_ratio = chunk_tokens_sum as f64 / config.soft_budget as f64;
+            let budget_penalty = (budget_ratio - 1.0).abs() * 0.1;
+
+            let chunk_score = alignment - budget_penalty;
+            let total = dp_score[j] + chunk_score;
+
+            if total > best_score {
+                best_score = total;
+                best_j = j;
+            }
+        }
+
+        dp_score[i] = best_score;
+        dp_back[i] = best_j;
+    }
+
+    // Backtrack to recover partition
+    let mut boundaries = Vec::new();
+    let mut pos = n;
+    while pos > 0 {
+        let start = dp_back[pos];
+        boundaries.push((start, pos));
+        pos = start;
+    }
+    boundaries.reverse();
+
+    // Step 7: Build IntentChunk vec
+    let partition_score = if n > 0 && !boundaries.is_empty() {
+        dp_score[n] / boundaries.len() as f64
+    } else {
+        0.0
+    };
+
+    let mut result_intents = intents;
+    let mut chunks = Vec::with_capacity(boundaries.len());
+
+    for (chunk_idx, &(start, end)) in boundaries.iter().enumerate() {
+        let chunk_text: String = blocks[start..end]
+            .iter()
+            .map(|b| b.text)
+            .collect::<Vec<_>>()
+            .join("");
+        let offset_start = blocks[start].offset;
+        let offset_end = blocks[end - 1].offset + blocks[end - 1].text.len();
+        let token_est = estimate_tokens(&chunk_text);
+        let chunk_centroid = centroid(&block_embeddings[start..end]);
+        let (best_intent_idx, alignment_score) =
+            best_intent_match(&chunk_centroid, &intent_embeddings);
+
+        // Track which chunks matched which intent
+        if best_intent_idx < result_intents.len() {
+            result_intents[best_intent_idx]
+                .matched_chunks
+                .push(chunk_idx);
+        }
+
+        let heading_path = heading_paths
+            .get(start)
+            .cloned()
+            .unwrap_or_default();
+
+        chunks.push(IntentChunk {
+            text: chunk_text,
+            offset_start,
+            offset_end,
+            token_estimate: token_est,
+            best_intent: best_intent_idx,
+            alignment_score,
+            heading_path,
+        });
+    }
+
+    Ok(IntentResult {
+        chunks,
+        intents: result_intents,
+        partition_score,
+        block_count,
+    })
+}
+
+/// Compute the centroid (element-wise mean) of a set of embeddings.
+fn centroid(embeddings: &[Vec<f64>]) -> Vec<f64> {
+    if embeddings.is_empty() {
+        return vec![];
+    }
+    let dim = embeddings[0].len();
+    let n = embeddings.len() as f64;
+    let mut result = vec![0.0; dim];
+    for emb in embeddings {
+        for (i, &val) in emb.iter().enumerate() {
+            result[i] += val;
+        }
+    }
+    for val in &mut result {
+        *val /= n;
+    }
+    result
+}
+
+/// Find the intent with highest cosine similarity to the given embedding.
+///
+/// Returns (intent_index, similarity_score).
+fn best_intent_match(embedding: &[f64], intent_embeddings: &[Vec<f64>]) -> (usize, f64) {
+    let mut best_idx = 0;
+    let mut best_sim = f64::NEG_INFINITY;
+
+    for (i, intent_emb) in intent_embeddings.iter().enumerate() {
+        let sim = cosine_similarity(embedding, intent_emb);
+        if sim > best_sim {
+            best_sim = sim;
+            best_idx = i;
+        }
+    }
+
+    (best_idx, best_sim.max(0.0))
+}
+
+/// Compute cosine similarity between two vectors.
+fn cosine_similarity(a: &[f64], b: &[f64]) -> f64 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+
+    let mut dot = 0.0;
+    let mut norm_a = 0.0;
+    let mut norm_b = 0.0;
+
+    for (&ai, &bi) in a.iter().zip(b.iter()) {
+        dot += ai * bi;
+        norm_a += ai * ai;
+        norm_b += bi * bi;
+    }
+
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom < 1e-12 {
+        return 0.0;
+    }
+
+    dot / denom
+}
+
+/// Estimate token count using whitespace splitting (fast approximation).
+fn estimate_tokens(text: &str) -> usize {
+    text.split_whitespace().count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cosine_similarity_identical() {
+        let a = vec![1.0, 2.0, 3.0];
+        let b = vec![1.0, 2.0, 3.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!((sim - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cosine_similarity_orthogonal() {
+        let a = vec![1.0, 0.0, 0.0];
+        let b = vec![0.0, 1.0, 0.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!(sim.abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cosine_similarity_opposite() {
+        let a = vec![1.0, 2.0, 3.0];
+        let b = vec![-1.0, -2.0, -3.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!((sim - (-1.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cosine_similarity_empty() {
+        let a: Vec<f64> = vec![];
+        let b: Vec<f64> = vec![];
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn test_cosine_similarity_mismatched_lengths() {
+        let a = vec![1.0, 2.0];
+        let b = vec![1.0, 2.0, 3.0];
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn test_centroid_single() {
+        let embeddings = vec![vec![1.0, 2.0, 3.0]];
+        let c = centroid(&embeddings);
+        assert_eq!(c, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn test_centroid_multiple() {
+        let embeddings = vec![vec![1.0, 0.0, 0.0], vec![0.0, 1.0, 0.0], vec![0.0, 0.0, 1.0]];
+        let c = centroid(&embeddings);
+        let expected = vec![1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0];
+        for (a, b) in c.iter().zip(expected.iter()) {
+            assert!((a - b).abs() < 1e-10);
+        }
+    }
+
+    #[test]
+    fn test_centroid_empty() {
+        let embeddings: Vec<Vec<f64>> = vec![];
+        let c = centroid(&embeddings);
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn test_estimate_tokens() {
+        assert_eq!(estimate_tokens("hello world"), 2);
+        assert_eq!(estimate_tokens("  one  two  three  "), 3);
+        assert_eq!(estimate_tokens(""), 0);
+        assert_eq!(estimate_tokens("single"), 1);
+    }
+
+    #[test]
+    fn test_best_intent_match() {
+        let embedding = vec![1.0, 0.0, 0.0];
+        let intent_embeddings = vec![
+            vec![0.0, 1.0, 0.0], // orthogonal
+            vec![1.0, 0.0, 0.0], // identical
+            vec![0.0, 0.0, 1.0], // orthogonal
+        ];
+        let (idx, score) = best_intent_match(&embedding, &intent_embeddings);
+        assert_eq!(idx, 1);
+        assert!((score - 1.0).abs() < 1e-10);
+    }
+}

--- a/src/semantic/intent_types.rs
+++ b/src/semantic/intent_types.rs
@@ -1,0 +1,45 @@
+//! Data types for intent-driven chunking.
+
+use serde::{Deserialize, Serialize};
+
+/// The type of user intent a query represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IntentType {
+    Factual,
+    Procedural,
+    Conceptual,
+    Comparative,
+}
+
+/// A predicted user query with its intent type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PredictedIntent {
+    pub query: String,
+    pub intent_type: IntentType,
+    #[serde(default)]
+    pub matched_chunks: Vec<usize>,
+}
+
+/// A chunk produced by intent-driven chunking.
+#[derive(Debug, Clone, Serialize)]
+pub struct IntentChunk {
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+    pub token_estimate: usize,
+    /// Index into the intents vec for the best-matching intent.
+    pub best_intent: usize,
+    /// Cosine similarity between chunk centroid and best intent embedding.
+    pub alignment_score: f64,
+    pub heading_path: Vec<String>,
+}
+
+/// Result of intent-driven chunking.
+#[derive(Debug)]
+pub struct IntentResult {
+    pub chunks: Vec<IntentChunk>,
+    pub intents: Vec<PredictedIntent>,
+    pub partition_score: f64,
+    pub block_count: usize,
+}

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -14,6 +14,8 @@ pub mod diagnostics;
 pub mod enrichment;
 pub mod evaluation;
 pub mod graph_export;
+pub mod intent_chunk;
+pub mod intent_types;
 pub mod proposition_heal;
 pub mod quality_metrics;
 pub mod sentence;

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -5,6 +5,8 @@
 //! Tables, code blocks, lists, and block quotes are kept as atomic units.
 //! Paragraphs are sentence-split for fine-grained boundary detection.
 
+pub mod adaptive_chunk;
+pub mod adaptive_types;
 pub mod blocks;
 pub mod cognitive_assemble;
 pub mod cognitive_rerank;

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -21,6 +21,9 @@ pub mod intent_types;
 pub mod proposition_heal;
 pub mod quality_metrics;
 pub mod sentence;
+pub mod sir;
+pub mod topo_chunk;
+pub mod topo_types;
 
 use anyhow::{Result, bail};
 

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -11,6 +11,8 @@ pub mod cognitive_rerank;
 pub mod cognitive_score;
 pub mod cognitive_types;
 pub mod diagnostics;
+pub mod enriched_chunk;
+pub mod enriched_types;
 pub mod enrichment;
 pub mod evaluation;
 pub mod graph_export;

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -15,6 +15,7 @@ pub mod enrichment;
 pub mod evaluation;
 pub mod graph_export;
 pub mod proposition_heal;
+pub mod quality_metrics;
 pub mod sentence;
 
 use anyhow::{Result, bail};

--- a/src/semantic/quality_metrics.rs
+++ b/src/semantic/quality_metrics.rs
@@ -10,9 +10,9 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::embeddings::EmbeddingProvider;
 use super::blocks::{BlockKind, split_blocks};
 use super::sentence::split_sentences;
+use crate::embeddings::EmbeddingProvider;
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -102,7 +102,11 @@ fn token_estimate(text: &str) -> usize {
 ///
 /// Returns 0.0 if either vector is zero.
 pub fn cosine_similarity(a: &[f64], b: &[f64]) -> f64 {
-    debug_assert_eq!(a.len(), b.len(), "cosine_similarity: vectors must have the same length");
+    debug_assert_eq!(
+        a.len(),
+        b.len(),
+        "cosine_similarity: vectors must have the same length"
+    );
 
     let dot: f64 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
     let norm_a: f64 = a.iter().map(|x| x * x).sum::<f64>().sqrt();
@@ -176,13 +180,9 @@ pub fn block_integrity(original_text: &str, chunks: &[ChunkForEval]) -> f64 {
 
 /// Orphan pronouns and demonstratives that should not start a chunk.
 const ORPHAN_PREFIXES: &[&str] = &[
-    "it ", "it's ", "its ",
-    "this ", "these ", "those ", "that ",
-    "they ", "them ", "their ", "they're ",
-    "he ", "he's ", "him ", "his ",
-    "she ", "she's ", "her ",
-    "we ", "we've ", "us ", "our ",
-    "there ", "here ",
+    "it ", "it's ", "its ", "this ", "these ", "those ", "that ", "they ", "them ", "their ",
+    "they're ", "he ", "he's ", "him ", "his ", "she ", "she's ", "her ", "we ", "we've ", "us ",
+    "our ", "there ", "here ",
 ];
 
 /// Fraction of chunks that do NOT start with an orphan pronoun/demonstrative.
@@ -370,7 +370,10 @@ mod tests {
     fn test_cosine_identical_vectors() {
         let v = vec![1.0, 2.0, 3.0];
         let sim = cosine_similarity(&v, &v);
-        assert!((sim - 1.0).abs() < 1e-10, "Identical vectors should have similarity 1.0, got {sim}");
+        assert!(
+            (sim - 1.0).abs() < 1e-10,
+            "Identical vectors should have similarity 1.0, got {sim}"
+        );
     }
 
     #[test]
@@ -378,7 +381,10 @@ mod tests {
         let a = vec![1.0, 0.0, 0.0];
         let b = vec![0.0, 1.0, 0.0];
         let sim = cosine_similarity(&a, &b);
-        assert!(sim.abs() < 1e-10, "Orthogonal vectors should have similarity 0.0, got {sim}");
+        assert!(
+            sim.abs() < 1e-10,
+            "Orthogonal vectors should have similarity 0.0, got {sim}"
+        );
     }
 
     #[test]
@@ -479,7 +485,7 @@ mod tests {
     fn test_rc_partial_orphans() {
         let chunks = vec![
             chunk("The system processes data.", 0),
-            chunk("This is fine.", 30),      // "this " is an orphan
+            chunk("This is fine.", 30),        // "this " is an orphan
             chunk("Performance is good.", 50), // clean start
         ];
         let rc = reference_completeness(&chunks);

--- a/src/semantic/quality_metrics.rs
+++ b/src/semantic/quality_metrics.rs
@@ -36,21 +36,26 @@ pub struct QualityMetrics {
 /// Weights for the composite score (should sum to 1.0).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetricWeights {
-    pub size_compliance: f64,
-    pub intrachunk_cohesion: f64,
-    pub contextual_coherence: f64,
-    pub block_integrity: f64,
-    pub reference_completeness: f64,
+    #[serde(alias = "size_compliance")]
+    pub sc: f64,
+    #[serde(alias = "intrachunk_cohesion")]
+    pub icc: f64,
+    #[serde(alias = "contextual_coherence")]
+    pub dcc: f64,
+    #[serde(alias = "block_integrity")]
+    pub bi: f64,
+    #[serde(alias = "reference_completeness")]
+    pub rc: f64,
 }
 
 impl Default for MetricWeights {
     fn default() -> Self {
         Self {
-            size_compliance: 0.20,
-            intrachunk_cohesion: 0.20,
-            contextual_coherence: 0.20,
-            block_integrity: 0.20,
-            reference_completeness: 0.20,
+            sc: 0.20,
+            icc: 0.20,
+            dcc: 0.20,
+            bi: 0.20,
+            rc: 0.20,
         }
     }
 }
@@ -105,22 +110,6 @@ pub fn cosine_similarity(a: &[f64], b: &[f64]) -> f64 {
         return 0.0;
     }
     (dot / (norm_a * norm_b)).clamp(-1.0, 1.0)
-}
-
-/// Compute the element-wise mean of a slice of vectors.
-fn mean_vector(vecs: &[Vec<f64>]) -> Vec<f64> {
-    if vecs.is_empty() {
-        return vec![];
-    }
-    let dim = vecs[0].len();
-    let mut sum = vec![0.0f64; dim];
-    for v in vecs {
-        for (s, x) in sum.iter_mut().zip(v.iter()) {
-            *s += x;
-        }
-    }
-    let n = vecs.len() as f64;
-    sum.iter().map(|s| s / n).collect()
 }
 
 // ── SC: Size Compliance ───────────────────────────────────────────────────────
@@ -198,6 +187,10 @@ const ORPHAN_PREFIXES: &[&str] = &[
 ///
 /// `orphan_count / boundary_count` is subtracted from 1.0.
 /// A single-chunk document returns 1.0 (no cross-chunk boundaries).
+///
+/// **Note:** This is a simplified implementation that checks pronoun/demonstrative orphans only.
+/// A full implementation could also track entity orphans — entities introduced in the previous
+/// chunk that are referenced in the next — matching the cognitive mode's entity continuity signal.
 pub fn reference_completeness(chunks: &[ChunkForEval]) -> f64 {
     if chunks.len() <= 1 {
         return 1.0;
@@ -216,7 +209,10 @@ pub fn reference_completeness(chunks: &[ChunkForEval]) -> f64 {
 
 // ── ICC: Intrachunk Cohesion ──────────────────────────────────────────────────
 
-/// Mean cosine similarity of sentence embeddings to their chunk centroid, averaged across chunks.
+/// Mean cosine similarity of sentence embeddings to the chunk embedding, averaged across chunks.
+///
+/// For each chunk: sentences and the full chunk text are embedded together (chunk last),
+/// then we compute the mean cosine similarity of each sentence embedding to the chunk embedding.
 ///
 /// Chunks with fewer than 2 sentences are skipped (trivially cohesive).
 /// Returns 1.0 for empty input.
@@ -247,30 +243,21 @@ pub async fn intrachunk_cohesion<P: EmbeddingProvider>(
         texts_to_embed.push(&chunk.text);
 
         let all_embeddings = provider.embed(&texts_to_embed).await?;
-        let (sentence_embeddings, chunk_embedding) = all_embeddings.split_at(sentences.len());
+        let (sentence_embeddings, chunk_emb_slice) = all_embeddings.split_at(sentences.len());
 
-        // Compute chunk centroid (mean of sentence embeddings)
-        let centroid = mean_vector(sentence_embeddings);
-        if centroid.is_empty() {
+        let chunk_emb = &chunk_emb_slice[0];
+        if chunk_emb.is_empty() {
             continue;
         }
 
-        // Mean cosine similarity of sentences to centroid
+        // Mean cosine similarity of each sentence embedding to the chunk embedding
         let mean_sim = sentence_embeddings
-            .iter()
-            .map(|e| cosine_similarity(e, &centroid))
-            .sum::<f64>()
-            / sentences.len() as f64;
-
-        // Also factor in similarity of each sentence to the full chunk embedding
-        let chunk_emb = &chunk_embedding[0];
-        let mean_to_chunk = sentence_embeddings
             .iter()
             .map(|e| cosine_similarity(e, chunk_emb))
             .sum::<f64>()
             / sentences.len() as f64;
 
-        scores.push((mean_sim + mean_to_chunk) / 2.0);
+        scores.push(mean_sim);
     }
 
     if scores.is_empty() {
@@ -309,11 +296,11 @@ pub async fn contextual_coherence<P: EmbeddingProvider>(
 
 /// Weighted sum of all five metric scores.
 pub fn composite_score(metrics: &QualityMetrics, weights: &MetricWeights) -> f64 {
-    weights.size_compliance * metrics.size_compliance
-        + weights.intrachunk_cohesion * metrics.intrachunk_cohesion
-        + weights.contextual_coherence * metrics.contextual_coherence
-        + weights.block_integrity * metrics.block_integrity
-        + weights.reference_completeness * metrics.reference_completeness
+    weights.sc * metrics.size_compliance
+        + weights.icc * metrics.intrachunk_cohesion
+        + weights.dcc * metrics.contextual_coherence
+        + weights.bi * metrics.block_integrity
+        + weights.rc * metrics.reference_completeness
 }
 
 // ── Main evaluation function ──────────────────────────────────────────────────

--- a/src/semantic/quality_metrics.rs
+++ b/src/semantic/quality_metrics.rs
@@ -64,7 +64,9 @@ impl Default for MetricWeights {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChunkForEval {
     pub text: String,
+    /// Byte offset of the chunk's start in the original source document.
     pub offset_start: usize,
+    /// Byte offset of the chunk's end in the original source document.
     pub offset_end: usize,
 }
 
@@ -243,6 +245,13 @@ pub async fn intrachunk_cohesion<P: EmbeddingProvider>(
         texts_to_embed.push(&chunk.text);
 
         let all_embeddings = provider.embed(&texts_to_embed).await?;
+        if all_embeddings.len() != texts_to_embed.len() {
+            anyhow::bail!(
+                "ICC: provider returned {} embeddings, expected {}",
+                all_embeddings.len(),
+                texts_to_embed.len()
+            );
+        }
         let (sentence_embeddings, chunk_emb_slice) = all_embeddings.split_at(sentences.len());
 
         let chunk_emb = &chunk_emb_slice[0];
@@ -282,6 +291,13 @@ pub async fn contextual_coherence<P: EmbeddingProvider>(
 
     let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
     let embeddings = provider.embed(&texts).await?;
+    if embeddings.len() != texts.len() {
+        anyhow::bail!(
+            "DCC: provider returned {} embeddings, expected {}",
+            embeddings.len(),
+            texts.len()
+        );
+    }
 
     let mut total = 0.0f64;
     let pairs = embeddings.len() - 1;

--- a/src/semantic/quality_metrics.rs
+++ b/src/semantic/quality_metrics.rs
@@ -1,0 +1,486 @@
+//! Intrinsic quality metrics for evaluating chunking output.
+//!
+//! Five metrics are provided:
+//! - **Size Compliance (SC):** fraction of chunks within the soft/hard token budget.
+//! - **Block Integrity (BI):** fraction of structural elements fully within one chunk.
+//! - **Reference Completeness (RC):** fraction of chunks not starting with orphan pronouns.
+//! - **Intrachunk Cohesion (ICC):** mean cosine similarity of sentences to their chunk centroid.
+//! - **Contextual Coherence (DCC):** mean cosine similarity between adjacent chunk embeddings.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::embeddings::EmbeddingProvider;
+use super::blocks::{BlockKind, split_blocks};
+use super::sentence::split_sentences;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/// All five intrinsic quality metrics plus a weighted composite.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QualityMetrics {
+    /// Fraction of chunks whose token count falls within [soft_budget/2, hard_budget].
+    pub size_compliance: f64,
+    /// Mean cosine similarity of sentence embeddings to their chunk centroid.
+    pub intrachunk_cohesion: f64,
+    /// Mean cosine similarity between adjacent chunk embeddings.
+    pub contextual_coherence: f64,
+    /// Fraction of structural elements (tables, code, lists, quotes) fully within one chunk.
+    pub block_integrity: f64,
+    /// Fraction of chunks not starting with an orphan pronoun/demonstrative.
+    pub reference_completeness: f64,
+    /// Weighted composite of all five metrics.
+    pub composite: f64,
+}
+
+/// Weights for the composite score (should sum to 1.0).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricWeights {
+    pub size_compliance: f64,
+    pub intrachunk_cohesion: f64,
+    pub contextual_coherence: f64,
+    pub block_integrity: f64,
+    pub reference_completeness: f64,
+}
+
+impl Default for MetricWeights {
+    fn default() -> Self {
+        Self {
+            size_compliance: 0.20,
+            intrachunk_cohesion: 0.20,
+            contextual_coherence: 0.20,
+            block_integrity: 0.20,
+            reference_completeness: 0.20,
+        }
+    }
+}
+
+/// A chunk ready for evaluation, with its text and byte offsets in the original document.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChunkForEval {
+    pub text: String,
+    pub offset_start: usize,
+    pub offset_end: usize,
+}
+
+/// Configuration for quality metric evaluation.
+#[derive(Debug, Clone)]
+pub struct MetricConfig {
+    /// Soft token budget (lower bound = soft_budget / 2).
+    pub soft_budget: usize,
+    /// Hard token budget (upper bound).
+    pub hard_budget: usize,
+    /// Weights for the composite score.
+    pub weights: MetricWeights,
+}
+
+impl Default for MetricConfig {
+    fn default() -> Self {
+        Self {
+            soft_budget: 512,
+            hard_budget: 768,
+            weights: MetricWeights::default(),
+        }
+    }
+}
+
+// ── Metric implementations ────────────────────────────────────────────────────
+
+/// Estimate token count by whitespace-splitting the text.
+fn token_estimate(text: &str) -> usize {
+    text.split_whitespace().count()
+}
+
+/// Compute cosine similarity between two equal-length vectors.
+///
+/// Returns 0.0 if either vector is zero.
+pub fn cosine_similarity(a: &[f64], b: &[f64]) -> f64 {
+    debug_assert_eq!(a.len(), b.len(), "cosine_similarity: vectors must have the same length");
+
+    let dot: f64 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_a: f64 = a.iter().map(|x| x * x).sum::<f64>().sqrt();
+    let norm_b: f64 = b.iter().map(|x| x * x).sum::<f64>().sqrt();
+
+    if norm_a == 0.0 || norm_b == 0.0 {
+        return 0.0;
+    }
+    (dot / (norm_a * norm_b)).clamp(-1.0, 1.0)
+}
+
+/// Compute the element-wise mean of a slice of vectors.
+fn mean_vector(vecs: &[Vec<f64>]) -> Vec<f64> {
+    if vecs.is_empty() {
+        return vec![];
+    }
+    let dim = vecs[0].len();
+    let mut sum = vec![0.0f64; dim];
+    for v in vecs {
+        for (s, x) in sum.iter_mut().zip(v.iter()) {
+            *s += x;
+        }
+    }
+    let n = vecs.len() as f64;
+    sum.iter().map(|s| s / n).collect()
+}
+
+// ── SC: Size Compliance ───────────────────────────────────────────────────────
+
+/// Fraction of chunks whose token count falls within `[soft_budget/2, hard_budget]`.
+///
+/// An empty chunk list returns 1.0 (vacuously true).
+pub fn size_compliance(chunks: &[ChunkForEval], soft_budget: usize, hard_budget: usize) -> f64 {
+    if chunks.is_empty() {
+        return 1.0;
+    }
+    let lower = soft_budget / 2;
+    let compliant = chunks
+        .iter()
+        .filter(|c| {
+            let tokens = token_estimate(&c.text);
+            tokens >= lower && tokens <= hard_budget
+        })
+        .count();
+    compliant as f64 / chunks.len() as f64
+}
+
+// ── BI: Block Integrity ───────────────────────────────────────────────────────
+
+/// Fraction of structural markdown elements fully contained within a single chunk's offset range.
+///
+/// Structural kinds: `Table`, `CodeBlock`, `List`, `BlockQuote`.
+/// Returns 1.0 if no structural elements are found.
+pub fn block_integrity(original_text: &str, chunks: &[ChunkForEval]) -> f64 {
+    let blocks = split_blocks(original_text);
+
+    let structural: Vec<_> = blocks
+        .iter()
+        .filter(|b| {
+            matches!(
+                b.kind,
+                BlockKind::Table | BlockKind::CodeBlock | BlockKind::List | BlockKind::BlockQuote
+            )
+        })
+        .collect();
+
+    if structural.is_empty() {
+        return 1.0;
+    }
+
+    let intact = structural
+        .iter()
+        .filter(|block| {
+            let block_start = block.offset;
+            let block_end = block.offset + block.text.len();
+            // A block is "intact" if it is fully within any single chunk
+            chunks
+                .iter()
+                .any(|c| c.offset_start <= block_start && block_end <= c.offset_end)
+        })
+        .count();
+
+    intact as f64 / structural.len() as f64
+}
+
+// ── RC: Reference Completeness ────────────────────────────────────────────────
+
+/// Orphan pronouns and demonstratives that should not start a chunk.
+const ORPHAN_PREFIXES: &[&str] = &[
+    "it ", "it's ", "its ",
+    "this ", "these ", "those ", "that ",
+    "they ", "them ", "their ", "they're ",
+    "he ", "he's ", "him ", "his ",
+    "she ", "she's ", "her ",
+    "we ", "we've ", "us ", "our ",
+    "there ", "here ",
+];
+
+/// Fraction of chunks that do NOT start with an orphan pronoun/demonstrative.
+///
+/// `orphan_count / boundary_count` is subtracted from 1.0.
+/// A single-chunk document returns 1.0 (no cross-chunk boundaries).
+pub fn reference_completeness(chunks: &[ChunkForEval]) -> f64 {
+    if chunks.len() <= 1 {
+        return 1.0;
+    }
+    // Only chunks after the first form cross-chunk boundaries
+    let boundary_count = chunks.len() - 1;
+    let orphan_count = chunks[1..]
+        .iter()
+        .filter(|c| {
+            let lower = c.text.to_lowercase();
+            ORPHAN_PREFIXES.iter().any(|p| lower.starts_with(p))
+        })
+        .count();
+    1.0 - (orphan_count as f64 / boundary_count as f64)
+}
+
+// ── ICC: Intrachunk Cohesion ──────────────────────────────────────────────────
+
+/// Mean cosine similarity of sentence embeddings to their chunk centroid, averaged across chunks.
+///
+/// Chunks with fewer than 2 sentences are skipped (trivially cohesive).
+/// Returns 1.0 for empty input.
+pub async fn intrachunk_cohesion<P: EmbeddingProvider>(
+    chunks: &[ChunkForEval],
+    provider: &P,
+) -> Result<f64> {
+    if chunks.is_empty() {
+        return Ok(1.0);
+    }
+
+    let mut scores = Vec::new();
+
+    for chunk in chunks {
+        let sentences: Vec<String> = split_sentences(&chunk.text)
+            .into_iter()
+            .map(|s| s.text.to_string())
+            .collect();
+
+        if sentences.len() < 2 {
+            // Single-sentence chunk is trivially cohesive
+            scores.push(1.0);
+            continue;
+        }
+
+        let sentence_refs: Vec<&str> = sentences.iter().map(|s| s.as_str()).collect();
+        let mut texts_to_embed = sentence_refs.clone();
+        texts_to_embed.push(&chunk.text);
+
+        let all_embeddings = provider.embed(&texts_to_embed).await?;
+        let (sentence_embeddings, chunk_embedding) = all_embeddings.split_at(sentences.len());
+
+        // Compute chunk centroid (mean of sentence embeddings)
+        let centroid = mean_vector(sentence_embeddings);
+        if centroid.is_empty() {
+            continue;
+        }
+
+        // Mean cosine similarity of sentences to centroid
+        let mean_sim = sentence_embeddings
+            .iter()
+            .map(|e| cosine_similarity(e, &centroid))
+            .sum::<f64>()
+            / sentences.len() as f64;
+
+        // Also factor in similarity of each sentence to the full chunk embedding
+        let chunk_emb = &chunk_embedding[0];
+        let mean_to_chunk = sentence_embeddings
+            .iter()
+            .map(|e| cosine_similarity(e, chunk_emb))
+            .sum::<f64>()
+            / sentences.len() as f64;
+
+        scores.push((mean_sim + mean_to_chunk) / 2.0);
+    }
+
+    if scores.is_empty() {
+        return Ok(1.0);
+    }
+    Ok(scores.iter().sum::<f64>() / scores.len() as f64)
+}
+
+// ── DCC: Contextual Coherence ────────────────────────────────────────────────
+
+/// Mean cosine similarity between adjacent chunk embeddings.
+///
+/// High values indicate smooth topic flow; low values indicate abrupt transitions.
+/// Returns 1.0 for fewer than 2 chunks.
+pub async fn contextual_coherence<P: EmbeddingProvider>(
+    chunks: &[ChunkForEval],
+    provider: &P,
+) -> Result<f64> {
+    if chunks.len() < 2 {
+        return Ok(1.0);
+    }
+
+    let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
+    let embeddings = provider.embed(&texts).await?;
+
+    let mut total = 0.0f64;
+    let pairs = embeddings.len() - 1;
+    for i in 0..pairs {
+        total += cosine_similarity(&embeddings[i], &embeddings[i + 1]);
+    }
+
+    Ok(total / pairs as f64)
+}
+
+// ── Composite ─────────────────────────────────────────────────────────────────
+
+/// Weighted sum of all five metric scores.
+pub fn composite_score(metrics: &QualityMetrics, weights: &MetricWeights) -> f64 {
+    weights.size_compliance * metrics.size_compliance
+        + weights.intrachunk_cohesion * metrics.intrachunk_cohesion
+        + weights.contextual_coherence * metrics.contextual_coherence
+        + weights.block_integrity * metrics.block_integrity
+        + weights.reference_completeness * metrics.reference_completeness
+}
+
+// ── Main evaluation function ──────────────────────────────────────────────────
+
+/// Evaluate all five intrinsic quality metrics for a set of chunks.
+///
+/// The `original_text` is used for block integrity analysis.
+/// The embedding `provider` is used for cohesion and coherence metrics.
+pub async fn evaluate_chunks<P: EmbeddingProvider>(
+    original_text: &str,
+    chunks: &[ChunkForEval],
+    provider: &P,
+    config: &MetricConfig,
+) -> Result<QualityMetrics> {
+    let sc = size_compliance(chunks, config.soft_budget, config.hard_budget);
+    let bi = block_integrity(original_text, chunks);
+    let rc = reference_completeness(chunks);
+    let icc = intrachunk_cohesion(chunks, provider).await?;
+    let dcc = contextual_coherence(chunks, provider).await?;
+
+    let mut metrics = QualityMetrics {
+        size_compliance: sc,
+        intrachunk_cohesion: icc,
+        contextual_coherence: dcc,
+        block_integrity: bi,
+        reference_completeness: rc,
+        composite: 0.0,
+    };
+    metrics.composite = composite_score(&metrics, &config.weights);
+
+    Ok(metrics)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chunk(text: &str, start: usize) -> ChunkForEval {
+        ChunkForEval {
+            text: text.to_string(),
+            offset_start: start,
+            offset_end: start + text.len(),
+        }
+    }
+
+    // ── cosine_similarity ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_cosine_identical_vectors() {
+        let v = vec![1.0, 2.0, 3.0];
+        let sim = cosine_similarity(&v, &v);
+        assert!((sim - 1.0).abs() < 1e-10, "Identical vectors should have similarity 1.0, got {sim}");
+    }
+
+    #[test]
+    fn test_cosine_orthogonal_vectors() {
+        let a = vec![1.0, 0.0, 0.0];
+        let b = vec![0.0, 1.0, 0.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!(sim.abs() < 1e-10, "Orthogonal vectors should have similarity 0.0, got {sim}");
+    }
+
+    #[test]
+    fn test_cosine_zero_vector() {
+        let a = vec![0.0, 0.0, 0.0];
+        let b = vec![1.0, 2.0, 3.0];
+        let sim = cosine_similarity(&a, &b);
+        assert_eq!(sim, 0.0, "Zero vector should yield 0.0");
+    }
+
+    // ── Size Compliance ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_sc_all_compliant() {
+        // 300 tokens is within [256, 768] (lower = 512/2 = 256, upper = 768)
+        let text = "word ".repeat(300);
+        let chunks = vec![chunk(&text, 0)];
+        let sc = size_compliance(&chunks, 512, 768);
+        assert_eq!(sc, 1.0, "All compliant → should return 1.0");
+    }
+
+    #[test]
+    fn test_sc_too_small() {
+        // 5 tokens < 256 (512/2)
+        let text = "one two three four five";
+        let chunks = vec![chunk(text, 0)];
+        let sc = size_compliance(&chunks, 512, 768);
+        assert_eq!(sc, 0.0, "Too-small chunk → should return 0.0");
+    }
+
+    #[test]
+    fn test_sc_empty_chunks() {
+        let sc = size_compliance(&[], 512, 768);
+        assert_eq!(sc, 1.0, "Empty list → vacuously 1.0");
+    }
+
+    #[test]
+    fn test_sc_mixed() {
+        // 400 tokens: within [256, 768] ✓
+        let big = "word ".repeat(400);
+        // 3 tokens: below lower bound of 256 ✗
+        let small = "tiny text here";
+        let chunks = vec![chunk(&big, 0), chunk(&small, 2000)];
+        let sc = size_compliance(&chunks, 512, 768);
+        // big is in range [256, 768], small is not
+        assert_eq!(sc, 0.5);
+    }
+
+    // ── Block Integrity ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_bi_no_structural_elements() {
+        let text = "Hello world. This is plain text. No tables or code here.";
+        let chunks = vec![chunk(text, 0)];
+        let bi = block_integrity(text, &chunks);
+        assert_eq!(bi, 1.0, "No structural elements → should return 1.0");
+    }
+
+    #[test]
+    fn test_bi_table_fully_contained() {
+        let text = "Intro.\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nOutro.\n";
+        let chunks = vec![chunk(text, 0)];
+        let bi = block_integrity(text, &chunks);
+        assert_eq!(bi, 1.0, "Table within single chunk → 1.0");
+    }
+
+    // ── Reference Completeness ────────────────────────────────────────────────
+
+    #[test]
+    fn test_rc_no_orphans() {
+        let chunks = vec![
+            chunk("The system processes data efficiently.", 0),
+            chunk("Performance is measured in throughput.", 50),
+            chunk("Results indicate high accuracy.", 100),
+        ];
+        let rc = reference_completeness(&chunks);
+        assert_eq!(rc, 1.0, "No orphans → should return 1.0");
+    }
+
+    #[test]
+    fn test_rc_with_orphan() {
+        let chunks = vec![
+            chunk("The system processes data.", 0),
+            chunk("it handles errors too.", 30),
+        ];
+        let rc = reference_completeness(&chunks);
+        assert_eq!(rc, 0.0, "All boundaries are orphans → should return 0.0");
+    }
+
+    #[test]
+    fn test_rc_single_chunk() {
+        let chunks = vec![chunk("Just one chunk.", 0)];
+        let rc = reference_completeness(&chunks);
+        assert_eq!(rc, 1.0, "Single chunk → no boundaries → 1.0");
+    }
+
+    #[test]
+    fn test_rc_partial_orphans() {
+        let chunks = vec![
+            chunk("The system processes data.", 0),
+            chunk("This is fine.", 30),      // "this " is an orphan
+            chunk("Performance is good.", 50), // clean start
+        ];
+        let rc = reference_completeness(&chunks);
+        // 1 orphan out of 2 boundaries
+        assert!((rc - 0.5).abs() < 1e-10, "Half orphans → 0.5, got {rc}");
+    }
+}

--- a/src/semantic/quality_metrics.rs
+++ b/src/semantic/quality_metrics.rs
@@ -427,7 +427,7 @@ mod tests {
         let big = "word ".repeat(400);
         // 3 tokens: below lower bound of 256 ✗
         let small = "tiny text here";
-        let chunks = vec![chunk(&big, 0), chunk(&small, 2000)];
+        let chunks = vec![chunk(&big, 0), chunk(small, 2000)];
         let sc = size_compliance(&chunks, 512, 768);
         // big is in range [256, 768], small is not
         assert_eq!(sc, 0.5);

--- a/src/semantic/sir.rs
+++ b/src/semantic/sir.rs
@@ -1,0 +1,74 @@
+//! Structured Intermediate Representation (SIR) for topology-aware chunking.
+//!
+//! The SIR captures document structure as a tree of section and content-block nodes,
+//! with cross-cutting edges for entity co-reference and discourse continuation.
+
+use serde::{Deserialize, Serialize};
+
+/// The type of a node in the SIR tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SirNodeType {
+    /// A section (heading-delimited region).
+    Section,
+    /// A leaf content block (sentence, table, code, list, etc.).
+    ContentBlock,
+}
+
+/// The type of a cross-cutting edge in the SIR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SirEdgeType {
+    /// Two non-adjacent blocks share entity mentions.
+    EntityCoref,
+    /// A block starts with a discourse continuation marker.
+    DiscourseContinuation,
+}
+
+/// A node in the SIR tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SirNode {
+    /// Unique node identifier.
+    pub id: usize,
+    /// Whether this is a section or content block.
+    pub node_type: SirNodeType,
+    /// Heading text (sections only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heading: Option<String>,
+    /// Heading level 1..=6 (sections only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heading_level: Option<u8>,
+    /// Serialized block kind (content blocks only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_type: Option<String>,
+    /// Range of block indices covered by this node (inclusive start, exclusive end).
+    pub block_range: (usize, usize),
+    /// Child node IDs.
+    pub children: Vec<usize>,
+    /// Preview of the text content (first 200 chars).
+    pub text_preview: String,
+    /// Estimated token count (~4 chars/token).
+    pub token_estimate: usize,
+}
+
+/// A cross-cutting edge between two SIR nodes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SirEdge {
+    /// Source node ID.
+    pub from: usize,
+    /// Target node ID.
+    pub to: usize,
+    /// Edge type.
+    pub edge_type: SirEdgeType,
+}
+
+/// The complete Structured Intermediate Representation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Sir {
+    /// All nodes in the SIR.
+    pub nodes: Vec<SirNode>,
+    /// Cross-cutting edges.
+    pub edges: Vec<SirEdge>,
+    /// Root node ID.
+    pub root: usize,
+}

--- a/src/semantic/topo_chunk.rs
+++ b/src/semantic/topo_chunk.rs
@@ -323,8 +323,8 @@ fn collect_splittable_texts(
     let mut parts: Vec<String> = Vec::new();
 
     for node in &sir.nodes {
-        if node.node_type == SirNodeType::Section {
-            if class_map.get(&node.id) == Some(&SectionClass::Splittable) {
+        if node.node_type == SirNodeType::Section
+            && class_map.get(&node.id) == Some(&SectionClass::Splittable) {
                 let (start, end) = node.block_range;
                 let text: String = blocks[start..end]
                     .iter()
@@ -333,7 +333,6 @@ fn collect_splittable_texts(
                     .join("\n");
                 parts.push(format!("--- Section {} (blocks {}..{}) ---\n{}", node.id, start, end, text));
             }
-        }
     }
 
     parts.join("\n\n")

--- a/src/semantic/topo_chunk.rs
+++ b/src/semantic/topo_chunk.rs
@@ -1,0 +1,552 @@
+//! Topology-aware chunking pipeline.
+//!
+//! Builds a Structured Intermediate Representation (SIR) from the document,
+//! then uses two LLM agents (Inspector + Refiner) to produce topology-preserving chunks.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::Result;
+
+use super::blocks::{Block, BlockKind, split_blocks};
+use super::enrichment::discourse::detect_discourse_markers;
+use super::enrichment::entities::extract_entities;
+use super::enrichment::heading_context::compute_heading_paths;
+use super::sir::{Sir, SirEdge, SirEdgeType, SirNode, SirNodeType};
+use super::topo_types::{
+    SectionClass, SectionClassification, TopoChunk, TopoResult,
+};
+use crate::llm::topo_agents::{inspect_sir, refine_partition};
+use crate::llm::CompletionClient;
+
+/// Configuration for topology-aware chunking.
+#[derive(Debug, Clone)]
+pub struct TopoConfig {
+    /// Soft token budget per chunk (default: 512).
+    pub soft_budget: usize,
+    /// Hard token ceiling per chunk (default: 768).
+    pub hard_budget: usize,
+    /// Whether to emit the SIR in the result (default: false).
+    pub emit_sir: bool,
+}
+
+impl Default for TopoConfig {
+    fn default() -> Self {
+        Self {
+            soft_budget: 512,
+            hard_budget: 768,
+            emit_sir: false,
+        }
+    }
+}
+
+/// Run the topology-aware chunking pipeline.
+///
+/// Requires markdown input (topo mode relies on heading structure).
+pub async fn topo_chunk(
+    text: &str,
+    llm_client: &CompletionClient,
+    _config: &TopoConfig,
+) -> Result<TopoResult> {
+    let blocks = split_blocks(text);
+    if blocks.is_empty() {
+        return Ok(TopoResult {
+            chunks: vec![],
+            sir: Sir {
+                nodes: vec![],
+                edges: vec![],
+                root: 0,
+            },
+            classifications: vec![],
+            block_count: 0,
+        });
+    }
+
+    let block_count = blocks.len();
+
+    // Step 1-2: Compute heading paths
+    let (heading_paths, heading_terms) = compute_heading_paths(&blocks);
+
+    // Step 3: Build SIR tree
+    let sir = build_sir(&blocks, &heading_paths, &heading_terms);
+
+    // Step 4: Call Inspector Agent
+    let sir_json = serde_json::to_string_pretty(&sir)?;
+    // Truncate if > 100k chars to fit LLM context
+    let sir_for_llm = if sir_json.len() > 100_000 {
+        sir_json[..100_000].to_string()
+    } else {
+        sir_json.clone()
+    };
+
+    let inspector_result = inspect_sir(llm_client, &sir_for_llm).await?;
+
+    // Build classification map
+    let mut classifications: Vec<SectionClassification> = Vec::new();
+    let mut class_map: HashMap<usize, SectionClass> = HashMap::new();
+    for ic in &inspector_result.classifications {
+        let class = match ic.class.as_str() {
+            "atomic" => SectionClass::Atomic,
+            "splittable" => SectionClass::Splittable,
+            "merge_candidate" => SectionClass::MergeCandidate,
+            _ => SectionClass::Atomic, // fallback
+        };
+        class_map.insert(ic.section_id, class);
+        classifications.push(SectionClassification {
+            section_id: ic.section_id,
+            class,
+            reason: ic.reason.clone(),
+        });
+    }
+
+    // Step 5: Collect text of splittable sections for the Refiner
+    let splittable_texts = collect_splittable_texts(&sir, &class_map, &blocks);
+    let inspector_json = serde_json::to_string_pretty(&inspector_result.classifications)?;
+
+    let refiner_result = refine_partition(
+        llm_client,
+        &inspector_json,
+        &sir_for_llm,
+        &splittable_texts,
+    )
+    .await?;
+
+    // Step 6: Assembly — map partition back to text spans
+    let chunks = assemble_chunks(
+        &refiner_result.partition,
+        &blocks,
+        &heading_paths,
+        &class_map,
+        &sir,
+    );
+
+    Ok(TopoResult {
+        chunks,
+        sir,
+        classifications,
+        block_count,
+    })
+}
+
+/// Build a SIR tree from parsed blocks and heading paths.
+pub fn build_sir(
+    blocks: &[Block<'_>],
+    _heading_paths: &[Vec<String>],
+    heading_terms: &HashSet<String>,
+) -> Sir {
+    let mut nodes: Vec<SirNode> = Vec::new();
+    let mut edges: Vec<SirEdge> = Vec::new();
+    let mut next_id: usize = 0;
+
+    // Create root node covering all blocks
+    let root_id = next_id;
+    next_id += 1;
+    nodes.push(SirNode {
+        id: root_id,
+        node_type: SirNodeType::Section,
+        heading: None,
+        heading_level: Some(0),
+        block_type: None,
+        block_range: (0, blocks.len()),
+        children: vec![],
+        text_preview: preview_text(blocks, 0, blocks.len()),
+        token_estimate: estimate_tokens_range(blocks, 0, blocks.len()),
+    });
+
+    // Walk blocks and create section nodes when headings are encountered
+    let mut section_stack: Vec<(usize, u8)> = vec![(root_id, 0)]; // (node_id, level)
+    let mut block_to_node: Vec<usize> = Vec::with_capacity(blocks.len());
+
+    for (i, block) in blocks.iter().enumerate() {
+        if block.kind == BlockKind::Heading {
+            let (level, heading_text) = parse_heading(block.text);
+
+            // Pop sections at same or deeper level
+            while section_stack.len() > 1
+                && section_stack.last().is_some_and(|(_, l)| *l >= level as u8)
+            {
+                section_stack.pop();
+            }
+
+            // Create section node
+            let section_id = next_id;
+            next_id += 1;
+
+            // Determine end range: scan forward to next heading at same or higher level
+            let section_end = find_section_end(blocks, i, level);
+
+            nodes.push(SirNode {
+                id: section_id,
+                node_type: SirNodeType::Section,
+                heading: Some(heading_text.to_string()),
+                heading_level: Some(level as u8),
+                block_type: None,
+                block_range: (i, section_end),
+                children: vec![],
+                text_preview: preview_text(blocks, i, section_end),
+                token_estimate: estimate_tokens_range(blocks, i, section_end),
+            });
+
+            // Add as child of current parent
+            let parent_id = section_stack.last().map(|(id, _)| *id).unwrap_or(root_id);
+            nodes[parent_id].children.push(section_id);
+
+            section_stack.push((section_id, level as u8));
+
+            // Map heading block to its section node
+            block_to_node.push(section_id);
+        } else {
+            // Create content block node
+            let block_id = next_id;
+            next_id += 1;
+
+            nodes.push(SirNode {
+                id: block_id,
+                node_type: SirNodeType::ContentBlock,
+                heading: None,
+                heading_level: None,
+                block_type: Some(format!("{:?}", block.kind)),
+                block_range: (i, i + 1),
+                children: vec![],
+                text_preview: truncate(block.text, 200),
+                token_estimate: block.text.len().div_ceil(4),
+            });
+
+            // Add as child of current section
+            let parent_id = section_stack.last().map(|(id, _)| *id).unwrap_or(root_id);
+            nodes[parent_id].children.push(block_id);
+
+            block_to_node.push(block_id);
+        }
+    }
+
+    // Add entity co-reference edges between non-adjacent blocks
+    let empty_stopwords: &[&str] = &["the", "a", "an", "of", "in", "to", "and", "or", "is", "are"];
+    let block_entities: Vec<Vec<_>> = blocks
+        .iter()
+        .map(|b| extract_entities(b.text, heading_terms, empty_stopwords))
+        .collect();
+
+    for i in 0..blocks.len() {
+        for j in (i + 2)..blocks.len() {
+            // Only non-adjacent blocks (skip i+1 since adjacent continuity is normal)
+            let overlap = crate::semantic::enrichment::entities::entity_overlap(
+                &block_entities[i],
+                &block_entities[j],
+            );
+            if overlap > 0.3 {
+                edges.push(SirEdge {
+                    from: block_to_node[i],
+                    to: block_to_node[j],
+                    edge_type: SirEdgeType::EntityCoref,
+                });
+            }
+        }
+    }
+
+    // Add discourse continuation edges
+    for (i, block) in blocks.iter().enumerate() {
+        if i > 0 && !detect_discourse_markers(block.text).is_empty() {
+            edges.push(SirEdge {
+                from: block_to_node[i - 1],
+                to: block_to_node[i],
+                edge_type: SirEdgeType::DiscourseContinuation,
+            });
+        }
+    }
+
+    Sir {
+        nodes,
+        edges,
+        root: root_id,
+    }
+}
+
+/// Find where a section ends (next heading at same or higher level, or end of document).
+fn find_section_end(blocks: &[Block<'_>], heading_idx: usize, heading_level: usize) -> usize {
+    for i in (heading_idx + 1)..blocks.len() {
+        if blocks[i].kind == BlockKind::Heading {
+            let (level, _) = parse_heading(blocks[i].text);
+            if level <= heading_level {
+                return i;
+            }
+        }
+    }
+    blocks.len()
+}
+
+/// Parse heading level and text from markdown heading block.
+fn parse_heading(text: &str) -> (usize, &str) {
+    let trimmed = text.trim();
+    let level = trimmed.chars().take_while(|&c| c == '#').count();
+    let heading_text = trimmed[level..].trim();
+    (level.max(1), heading_text)
+}
+
+/// Estimate tokens for a range of blocks.
+pub fn estimate_tokens_range(blocks: &[Block<'_>], start: usize, end: usize) -> usize {
+    blocks[start..end]
+        .iter()
+        .map(|b| b.text.len())
+        .sum::<usize>()
+        .div_ceil(4)
+}
+
+/// Build a text preview from a range of blocks.
+fn preview_text(blocks: &[Block<'_>], start: usize, end: usize) -> String {
+    let combined: String = blocks[start..end]
+        .iter()
+        .map(|b| b.text)
+        .collect::<Vec<_>>()
+        .join(" ");
+    truncate(&combined, 200)
+}
+
+/// Truncate a string to max_len characters.
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        let mut end = max_len;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
+    }
+}
+
+/// Collect full text of splittable sections for the Refiner.
+fn collect_splittable_texts(
+    sir: &Sir,
+    class_map: &HashMap<usize, SectionClass>,
+    blocks: &[Block<'_>],
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    for node in &sir.nodes {
+        if node.node_type == SirNodeType::Section {
+            if class_map.get(&node.id) == Some(&SectionClass::Splittable) {
+                let (start, end) = node.block_range;
+                let text: String = blocks[start..end]
+                    .iter()
+                    .map(|b| b.text)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                parts.push(format!("--- Section {} (blocks {}..{}) ---\n{}", node.id, start, end, text));
+            }
+        }
+    }
+
+    parts.join("\n\n")
+}
+
+/// Assemble chunks from the Refiner's partition.
+fn assemble_chunks(
+    partition: &[crate::llm::topo_agents::RefinerChunk],
+    blocks: &[Block<'_>],
+    heading_paths: &[Vec<String>],
+    class_map: &HashMap<usize, SectionClass>,
+    sir: &Sir,
+) -> Vec<TopoChunk> {
+    let mut chunks = Vec::new();
+
+    for part in partition {
+        let start = part.block_range.first().copied().unwrap_or(0);
+        let end = part.block_range.get(1).copied().unwrap_or(blocks.len());
+
+        // Clamp to valid range
+        let start = start.min(blocks.len());
+        let end = end.min(blocks.len()).max(start);
+
+        if start >= blocks.len() || start == end {
+            continue;
+        }
+
+        let text: String = blocks[start..end]
+            .iter()
+            .map(|b| b.text)
+            .collect::<Vec<_>>()
+            .join("");
+
+        let offset_start = blocks[start].offset;
+        let offset_end = blocks[end - 1].offset + blocks[end - 1].text.len();
+        let token_estimate = text.len().div_ceil(4);
+
+        let heading_path = if start < heading_paths.len() {
+            heading_paths[start].clone()
+        } else {
+            vec![]
+        };
+
+        // Determine classification label from section_ids
+        let classification = part
+            .section_ids
+            .first()
+            .and_then(|sid| class_map.get(sid))
+            .map(|c| match c {
+                SectionClass::Atomic => "atomic",
+                SectionClass::Splittable => "splittable",
+                SectionClass::MergeCandidate => "merged",
+            })
+            .unwrap_or("atomic")
+            .to_string();
+
+        // Find cross-references from SIR edges
+        let cross_references = find_cross_references(sir, start, end, chunks.len());
+
+        chunks.push(TopoChunk {
+            text,
+            offset_start,
+            offset_end,
+            token_estimate,
+            heading_path,
+            section_classification: classification,
+            cross_references,
+        });
+    }
+
+    chunks
+}
+
+/// Find other chunk indices that share entity co-reference edges with this block range.
+fn find_cross_references(sir: &Sir, start: usize, end: usize, _current_chunk: usize) -> Vec<usize> {
+    let mut refs = Vec::new();
+    for edge in &sir.edges {
+        if edge.edge_type == SirEdgeType::EntityCoref {
+            // Check if one end is in our range and the other is outside
+            let from_node = sir.nodes.iter().find(|n| n.id == edge.from);
+            let to_node = sir.nodes.iter().find(|n| n.id == edge.to);
+
+            if let (Some(from), Some(to)) = (from_node, to_node) {
+                let from_in = from.block_range.0 >= start && from.block_range.0 < end;
+                let to_in = to.block_range.0 >= start && to.block_range.0 < end;
+
+                if from_in && !to_in {
+                    refs.push(to.block_range.0);
+                } else if to_in && !from_in {
+                    refs.push(from.block_range.0);
+                }
+            }
+        }
+    }
+    refs.sort();
+    refs.dedup();
+    refs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_sir_basic() {
+        let md = "\
+# Introduction
+
+This is the introduction.
+
+## Architecture
+
+The architecture is modular.
+It supports multiple providers.
+
+### Scoring
+
+The scoring formula is complex.
+
+## Evaluation
+
+Evaluation details here.
+";
+        let blocks = split_blocks(md);
+        let (heading_paths, heading_terms) = compute_heading_paths(&blocks);
+        let sir = build_sir(&blocks, &heading_paths, &heading_terms);
+
+        // Root node should exist
+        assert_eq!(sir.root, 0);
+        assert_eq!(sir.nodes[0].node_type, SirNodeType::Section);
+        assert_eq!(sir.nodes[0].block_range.0, 0);
+        assert_eq!(sir.nodes[0].block_range.1, blocks.len());
+
+        // Should have section nodes for each heading
+        let sections: Vec<_> = sir
+            .nodes
+            .iter()
+            .filter(|n| n.node_type == SirNodeType::Section && n.heading.is_some())
+            .collect();
+        assert!(
+            sections.len() >= 4,
+            "Should have sections for Introduction, Architecture, Scoring, Evaluation, got {}",
+            sections.len()
+        );
+
+        // Content blocks should exist
+        let content_blocks: Vec<_> = sir
+            .nodes
+            .iter()
+            .filter(|n| n.node_type == SirNodeType::ContentBlock)
+            .collect();
+        assert!(!content_blocks.is_empty(), "Should have content blocks");
+    }
+
+    #[test]
+    fn test_build_sir_flat_document() {
+        let md = "\
+Just a paragraph without any headings.
+Another paragraph here.
+";
+        let blocks = split_blocks(md);
+        let (heading_paths, heading_terms) = compute_heading_paths(&blocks);
+        let sir = build_sir(&blocks, &heading_paths, &heading_terms);
+
+        // Should still have a root node
+        assert_eq!(sir.root, 0);
+        assert_eq!(sir.nodes[0].node_type, SirNodeType::Section);
+
+        // No section children (no headings), only content blocks
+        let sections_with_heading: Vec<_> = sir
+            .nodes
+            .iter()
+            .filter(|n| n.node_type == SirNodeType::Section && n.heading.is_some())
+            .collect();
+        assert_eq!(
+            sections_with_heading.len(),
+            0,
+            "Flat document should have no heading sections"
+        );
+
+        // But should have content block nodes
+        let content_blocks: Vec<_> = sir
+            .nodes
+            .iter()
+            .filter(|n| n.node_type == SirNodeType::ContentBlock)
+            .collect();
+        assert!(
+            content_blocks.len() >= 1,
+            "Should have at least one content block"
+        );
+    }
+
+    #[test]
+    fn test_estimate_tokens() {
+        let blocks = vec![
+            Block {
+                text: "Hello world, this is a test sentence with some words.",
+                offset: 0,
+                kind: BlockKind::Sentence,
+            },
+            Block {
+                text: "Another sentence here.",
+                offset: 53,
+                kind: BlockKind::Sentence,
+            },
+        ];
+
+        let total = estimate_tokens_range(&blocks, 0, 2);
+        // 53 + 22 = 75 chars -> ceil(75/4) = 19 tokens
+        assert_eq!(total, 19);
+
+        let first_only = estimate_tokens_range(&blocks, 0, 1);
+        // 53 chars -> ceil(53/4) = 14
+        assert_eq!(first_only, 14);
+    }
+}

--- a/src/semantic/topo_chunk.rs
+++ b/src/semantic/topo_chunk.rs
@@ -12,11 +12,9 @@ use super::enrichment::discourse::detect_discourse_markers;
 use super::enrichment::entities::extract_entities;
 use super::enrichment::heading_context::compute_heading_paths;
 use super::sir::{Sir, SirEdge, SirEdgeType, SirNode, SirNodeType};
-use super::topo_types::{
-    SectionClass, SectionClassification, TopoChunk, TopoResult,
-};
-use crate::llm::topo_agents::{inspect_sir, refine_partition};
+use super::topo_types::{SectionClass, SectionClassification, TopoChunk, TopoResult};
 use crate::llm::CompletionClient;
+use crate::llm::topo_agents::{inspect_sir, refine_partition};
 
 /// Configuration for topology-aware chunking.
 #[derive(Debug, Clone)]
@@ -102,13 +100,8 @@ pub async fn topo_chunk(
     let splittable_texts = collect_splittable_texts(&sir, &class_map, &blocks);
     let inspector_json = serde_json::to_string_pretty(&inspector_result.classifications)?;
 
-    let refiner_result = refine_partition(
-        llm_client,
-        &inspector_json,
-        &sir_for_llm,
-        &splittable_texts,
-    )
-    .await?;
+    let refiner_result =
+        refine_partition(llm_client, &inspector_json, &sir_for_llm, &splittable_texts).await?;
 
     // Step 6: Assembly — map partition back to text spans
     let chunks = assemble_chunks(
@@ -263,9 +256,9 @@ pub fn build_sir(
 
 /// Find where a section ends (next heading at same or higher level, or end of document).
 fn find_section_end(blocks: &[Block<'_>], heading_idx: usize, heading_level: usize) -> usize {
-    for i in (heading_idx + 1)..blocks.len() {
-        if blocks[i].kind == BlockKind::Heading {
-            let (level, _) = parse_heading(blocks[i].text);
+    for (i, block) in blocks.iter().enumerate().skip(heading_idx + 1) {
+        if block.kind == BlockKind::Heading {
+            let (level, _) = parse_heading(block.text);
             if level <= heading_level {
                 return i;
             }
@@ -324,15 +317,19 @@ fn collect_splittable_texts(
 
     for node in &sir.nodes {
         if node.node_type == SirNodeType::Section
-            && class_map.get(&node.id) == Some(&SectionClass::Splittable) {
-                let (start, end) = node.block_range;
-                let text: String = blocks[start..end]
-                    .iter()
-                    .map(|b| b.text)
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                parts.push(format!("--- Section {} (blocks {}..{}) ---\n{}", node.id, start, end, text));
-            }
+            && class_map.get(&node.id) == Some(&SectionClass::Splittable)
+        {
+            let (start, end) = node.block_range;
+            let text: String = blocks[start..end]
+                .iter()
+                .map(|b| b.text)
+                .collect::<Vec<_>>()
+                .join("\n");
+            parts.push(format!(
+                "--- Section {} (blocks {}..{}) ---\n{}",
+                node.id, start, end, text
+            ));
+        }
     }
 
     parts.join("\n\n")

--- a/src/semantic/topo_chunk.rs
+++ b/src/semantic/topo_chunk.rs
@@ -517,7 +517,7 @@ Another paragraph here.
             .filter(|n| n.node_type == SirNodeType::ContentBlock)
             .collect();
         assert!(
-            content_blocks.len() >= 1,
+            !content_blocks.is_empty(),
             "Should have at least one content block"
         );
     }

--- a/src/semantic/topo_types.rs
+++ b/src/semantic/topo_types.rs
@@ -1,0 +1,60 @@
+//! Data types for topology-aware chunking output.
+
+use serde::{Deserialize, Serialize};
+
+use super::sir::Sir;
+
+/// Classification of how a section should be treated during chunking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SectionClass {
+    /// Section is small enough to be a single chunk.
+    Atomic,
+    /// Section is too large and must be split.
+    Splittable,
+    /// Section is too small and should be merged with neighbours.
+    MergeCandidate,
+}
+
+/// Inspector-produced classification for a single section.
+#[derive(Debug, Clone, Serialize)]
+pub struct SectionClassification {
+    /// SIR node ID of the section.
+    pub section_id: usize,
+    /// How the section should be treated.
+    pub class: SectionClass,
+    /// Reasoning from the Inspector agent.
+    pub reason: String,
+}
+
+/// A chunk produced by topology-aware chunking.
+#[derive(Debug, Clone, Serialize)]
+pub struct TopoChunk {
+    /// The chunk text.
+    pub text: String,
+    /// Byte offset of chunk start in the source document.
+    pub offset_start: usize,
+    /// Byte offset of chunk end in the source document.
+    pub offset_end: usize,
+    /// Estimated token count.
+    pub token_estimate: usize,
+    /// Heading ancestry path for this chunk.
+    pub heading_path: Vec<String>,
+    /// How this section was classified: "atomic", "splittable", or "merged".
+    pub section_classification: String,
+    /// Indices of other chunks that share entity cross-references.
+    pub cross_references: Vec<usize>,
+}
+
+/// Result of the topology-aware chunking pipeline.
+#[derive(Debug)]
+pub struct TopoResult {
+    /// The produced chunks.
+    pub chunks: Vec<TopoChunk>,
+    /// The SIR built from the document.
+    pub sir: Sir,
+    /// Section classifications from the Inspector.
+    pub classifications: Vec<SectionClassification>,
+    /// Total number of blocks parsed.
+    pub block_count: usize,
+}


### PR DESCRIPTION
## Release v2.1.0

Promotes `develop` → `main` for the v2.1.0 release.

### Highlights

**4 new chunking methods** (#22):
- `intent` — LLM-predicted query alignment + dynamic programming
- `enriched` — single-call 7-field metadata + semantic-key recombination
- `topo` — SIR tree + dual LLM agents (Inspector/Refiner)
- `adaptive` — meta-router with 5 quality metrics

**Quality metrics module**: `POST /api/v1/evaluate` endpoint + standalone `evaluate_chunks()` for benchmarking.

**Python bindings** (#23): full parity with Rust crate — all 4 new methods + quality metrics exposed.

**Infrastructure**:
- clap 4.6, tokio 1.51, unicode-segmentation 1.13, pulldown-cmark 0.13.3
- Main crate bumped 2.0.0 → 2.1.0 (#24)
- Python package bumped 0.1.0 → 0.2.0

### Test plan

- [x] 149 tests pass on develop
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] All 4 new methods verified end-to-end against real sample documents
- [x] Python wheel built successfully, imports verified